### PR TITLE
[DEVHAS-152] patches order in overlays kustomization file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Eidtor settings
+.idea/
+.vscode/

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -750,7 +750,7 @@ func TestGenerateOverlays(t *testing.T) {
 					"patch1.yaml",
 				},
 			},
-			expectPatchEntries: 2,
+			expectPatchEntries: 3,
 			wantErr:            "",
 		},
 	}
@@ -784,7 +784,7 @@ func TestGenerateOverlays(t *testing.T) {
 
 				// There match patch entries in the kustomization file
 				if len(k.Patches) != tt.expectPatchEntries {
-					t.Errorf("expected %v kustomization bases, got %v", 3, len(k.Patches))
+					t.Errorf("expected %v kustomization bases, got %v patches: %v", tt.expectPatchEntries, len(k.Patches), k.Patches)
 				}
 
 				// Validate that the APIVersion and Kind are set properly

--- a/pkg/resources/kustomization.go
+++ b/pkg/resources/kustomization.go
@@ -57,15 +57,19 @@ func removeDuplicatesAndSort(s []string) []string {
 }
 
 func (k *Kustomization) CompareDifferenceAndAddCustomPatches(original []string, generated []string) {
-	generatedPatches := make(map[string]bool)
-	for _, genratedElement := range generated {
-		generatedPatches[genratedElement] = true
-	}
-
+	newPatchesList := original
+	newGeneratedFiles := []string{}
+	originalPatches := make(map[string]bool)
 	for _, originalElement := range original {
-		// if the patch is not generated
-		if _, ok := generatedPatches[originalElement]; !ok {
-			k.AddPatches(originalElement)
+		originalPatches[originalElement] = true
+	}
+	for _, generatedElement := range generated {
+		if _, ok := originalPatches[generatedElement]; !ok {
+			// preserve the newGeneratedFiles order
+			newGeneratedFiles = append(newGeneratedFiles, generatedElement)
 		}
 	}
+	// new generated files should add to the top of the patch list
+	newPatchesList = append(newGeneratedFiles, newPatchesList...)
+	k.Patches = newPatchesList
 }

--- a/pkg/resources/kustomization_test.go
+++ b/pkg/resources/kustomization_test.go
@@ -71,9 +71,9 @@ func Test_AddResource_sorts_elements(t *testing.T) {
 func Test_CompareDifferenceAndAddCustomizedPatches(t *testing.T) {
 	k := Kustomization{}
 	original := []string{"testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}
-	generated := []string{"testing.yaml", "testing2.yaml"}
+	generated := []string{"testing.yaml", "testing2.yaml", "testing3.yaml"}
 	k.CompareDifferenceAndAddCustomPatches(original, generated)
-	if diff := cmp.Diff([]string{"custom.yaml", "custom2.yaml"}, k.Patches); diff != "" {
+	if diff := cmp.Diff([]string{"testing3.yaml", "testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}, k.Patches); diff != "" {
 		t.Fatalf("failed to add customized patches:\n%s", diff)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>
preserve patches order and pre-empt custom patches over newly generated ones



To test:
apply the changes to HAS

1. create ha, hc,env, snapshot,binding
2. update the component overlays kustomization patch list to include 1-2new custom patch
3. update the binding
4. check the gitops repo to see if the patch order has been preserved. 

5. remove the  generated `deployment-patch` from component overlays kustomization patch list
6. update the binding
7. check the gitops repo to see if the generated patch is added at the top
