### PR TITLE
Only validate remote if cloning or pushing, since they are optional

### DIFF
--- a/pkg/gitops.go
+++ b/pkg/gitops.go
@@ -240,9 +240,11 @@ func GenerateAndPush(outputPath string, remote string, options gitopsv1alpha1.Ge
 // 14. The gitops config containing the build bundle;
 func GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, e Executor, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error {
 
-	invalidRemoteErr := util.ValidateRemote(remote)
-	if invalidRemoteErr != nil {
-		return invalidRemoteErr
+	if clone || doPush {
+		invalidRemoteErr := util.ValidateRemote(remote)
+		if invalidRemoteErr != nil {
+			return invalidRemoteErr
+		}
 	}
 
 	componentName := options.Name


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

### What does this PR do?:
KAM is calling the CloneGenerateAndPush API and not cloning or pushing the changes.  So the git URL is an empty string.  We want the remote URL validation done only if cloning or pushing is done, since a valid remote will be needed in those cases.

For RemoveAndPush, will make any related changes in this PR:

https://github.com/redhat-developer/gitops-generator/pull/24

In all the other cases (functions) where the remote validation is done, eg. CloneGenerateAndPush, doing the validation seems fine, without adding the if-conditions.

### Which issue(s)/story(ies) does this PR fixes:
N/A

### PR acceptance criteria:
N/A

