### PR TITLE
[DEVHAS-133] Sanitize Error Messages

### DIFF
--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1,0 +1,156 @@
+//
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitops
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/gitops-generator/pkg/util"
+)
+
+type GitCmd string
+
+const (
+	cloneRepo      GitCmd = "clone git"
+	checkGitDiff   GitCmd = "check git diff"
+	commitFiles    GitCmd = "commit files"
+	pushRemote     GitCmd = "push remote"
+	initializeGit  GitCmd = "initialize git"
+	addComponents  GitCmd = "add components"
+	getCommitID    GitCmd = "retrieve commit id"
+	switchBranch   GitCmd = "switch to"
+	checkoutBranch GitCmd = "checkout"
+	genOverlays    GitCmd = "overlays dir"
+)
+
+// GitCmdError is used to construct custom errors for a number of git commands that follow similar message patterns
+// Used by the following command types:  cloneRepo, checkGitDiff, commitFiles, pushRemote, initializeGit, addComponents, getCommitID
+
+type GitCmdError struct {
+	path      string
+	cmdResult string
+	err       error
+	cmdType   GitCmd
+}
+
+func (e *GitCmdError) Error() string {
+
+	// Check to see what gitops actions have take place in order to append the correct preposition
+	cmdMsg := e.cmdType
+	if e.cmdType == checkGitDiff {
+		cmdMsg = cmdMsg + " in"
+	} else if e.cmdType == commitFiles || e.cmdType == pushRemote {
+		cmdMsg = cmdMsg + " to"
+	} else if e.cmdType == getCommitID {
+		cmdMsg = cmdMsg + " for"
+	}
+
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to %s repository %q %q: %s", cmdMsg, e.path, e.cmdResult, e.err)).Error()
+}
+
+// GitBranchError is used to construct custom errors related to git branch failures
+// Used by the following command types: switchBranch, checkoutBranch
+type GitBranchError struct {
+	branch    string
+	repoPath  string
+	cmdResult string
+	err       error
+	cmdType   GitCmd
+}
+
+func (e *GitBranchError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to %s branch %q in repository %q %q: %s", e.cmdType, e.branch, e.repoPath, string(e.cmdResult), e.err)).Error()
+}
+
+type GitGenResourcesAndOverlaysError struct {
+	path          string
+	componentName string
+	err           error
+	cmdType       GitCmd
+}
+
+func (e *GitGenResourcesAndOverlaysError) Error() string {
+	failedToGenerate := "failed to generate the gitops resources in "
+	if e.cmdType == genOverlays {
+		failedToGenerate = failedToGenerate + string(genOverlays) + " "
+	}
+	return util.SanitizeErrorMessage(fmt.Errorf(failedToGenerate+"%q for component %q: %s", e.path, e.componentName, e.err)).Error()
+}
+
+// DeleteFolderError is used to construct a custom error if component removal fails
+type DeleteFolderError struct {
+	componentPath string
+	repoPath      string
+	cmdResult     string
+	err           error
+}
+
+func (e *DeleteFolderError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to delete %q folder in repository in %q %q: %s", e.componentPath, e.repoPath, e.cmdResult, e.err)).Error()
+}
+
+// GitCreateRepoError is used to construct a custom error if repo creation fails
+type GitCreateRepoError struct {
+	repoName string
+	org      string
+	err      error
+}
+
+func (e *GitCreateRepoError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to create repository %q in namespace %q: %w", e.repoName, e.org, e.err)).Error()
+}
+
+// GitAddFilesToRemoteError is used to construct a custom error if adding files to remote repo fails
+type GitAddFilesToRemoteError struct {
+	componentName string
+	remoteURL     string
+	repoPath      string
+	cmdResult     string
+	err           error
+}
+
+func (e *GitAddFilesToRemoteError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to add files for component %q, to remote 'origin' %q to repository in %q %q: %s", e.componentName, e.remoteURL, e.repoPath, e.cmdResult, e.err)).Error()
+}
+
+type GitAddFilesError struct {
+	componentName string
+	repoPath      string
+	cmdResult     string
+	err           error
+}
+
+func (e *GitAddFilesError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to add files for component %q to repository in %q %q: %s", e.componentName, e.repoPath, e.cmdResult, e.err)).Error()
+}
+
+type GitOpsRepoGenError struct {
+	gitopsURL string
+	errMsg    string
+	err       error
+}
+
+func (e *GitOpsRepoGenError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf(e.errMsg, e.gitopsURL, e.err)).Error()
+}
+
+type GitOpsRepoGenUserError struct {
+	err error
+}
+
+func (e *GitOpsRepoGenUserError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to get the user with their auth token: %w", e.err)).Error()
+}

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -52,7 +52,7 @@ func (e *GitCmdError) Error() string {
 	cmdMsg := e.cmdType
 	if e.cmdType == checkGitDiff {
 		cmdMsg = cmdMsg + " in"
-	} else if e.cmdType == commitFiles || e.cmdType == pushRemote {
+	} else if e.cmdType == commitFiles || e.cmdType == pushRemote || e.cmdType == addComponents {
 		cmdMsg = cmdMsg + " to"
 	} else if e.cmdType == getCommitID {
 		cmdMsg = cmdMsg + " for"

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -2221,7 +2221,7 @@ func createEmptyGitRepository(repoPath string) error {
 func getCommitIDFromDotGit(repoPath string) (string, error) {
 	fs := ioutils.NewFilesystem()
 	var fileBytes []byte
-	fileBytes, err := fs.ReadFile(filepath.Join(repoPath, ".git", "refs", "heads", "main"))
+	fileBytes, err := fs.ReadFile(filepath.Join(repoPath, ".git", "refs", "heads", "master"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -25,6 +25,7 @@ import (
 
 	gitopsv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-generator/pkg/testutils"
+	"github.com/redhat-developer/gitops-generator/pkg/util"
 	"github.com/redhat-developer/gitops-generator/pkg/util/ioutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,7 @@ var originalExecute = execute
 
 func TestCloneGenerateAndPush(t *testing.T) {
 	repo := "https://github.com/testing/testing.git"
+	repoWithToken := "https://ghu_28lafsjdifouwej@github.com/testing/testing.git"
 	outputPath := "/fake/path"
 	repoPath := "/fake/path/test-component"
 	componentName := "test-component"
@@ -51,6 +53,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		repo          string
 		fs            afero.Afero
 		component     gitopsv1alpha1.GeneratorOptions
 		errors        *testutils.ErrorStack
@@ -60,6 +63,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 	}{
 		{
 			name:      "No errors",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors:    &testutils.ErrorStack{},
@@ -112,6 +116,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "Git clone failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -135,6 +140,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "Git switch failure, git checkout failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -166,10 +172,11 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					Args:    []string{"checkout", "-b", "main"},
 				},
 			},
-			wantErrString: "failed to checkout branch \"main\" in \"/fake/path/test-component\" \"test output1\": Permission denied",
+			wantErrString: "failed to checkout branch \"main\" in repository \"/fake/path/test-component\" \"test output1\": Permission denied",
 		},
 		{
 			name:      "Git switch failure, git checkout success",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -235,6 +242,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "rm -rf failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -270,6 +278,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "git add failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -312,6 +321,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "git diff failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -361,6 +371,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name:      "git commit failure",
+			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -413,10 +424,11 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					Args:    []string{"commit", "-m", fmt.Sprintf("Generate GitOps base resources for component %s", componentName)},
 				},
 			},
-			wantErrString: "failed to commit files to repository in \"/fake/path/test-component\" \"test output1\": Fatal error",
+			wantErrString: "failed to commit files to repository \"/fake/path/test-component\" \"test output1\": Fatal error",
 		},
 		{
-			name:      "git push failure",
+			name:      "git push failure with sanitized error message",
+			repo:      repoWithToken,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
@@ -443,7 +455,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				{
 					BaseDir: outputPath,
 					Command: "git",
-					Args:    []string{"clone", repo, component.Name},
+					Args:    []string{"clone", repoWithToken, component.Name},
 				},
 				{
 					BaseDir: repoPath,
@@ -476,10 +488,11 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					Args:    []string{"push", "origin", "main"},
 				},
 			},
-			wantErrString: fmt.Sprintf("failed push remote to repository \"%s\" \"test output1\": Fatal error", repo),
+			wantErrString: util.SanitizeErrorMessage(fmt.Errorf("failed to push remote to repository \"%s\" \"test output1\": Fatal error", repoWithToken)).Error(),
 		},
 		{
 			name:      "gitops generate failure",
+			repo:      repo,
 			fs:        readOnlyFs,
 			component: component,
 			errors:    &testutils.ErrorStack{},
@@ -504,6 +517,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 		},
 		{
 			name: "gitops generate failure - image component",
+			repo: repo,
 			fs:   readOnlyFs,
 			component: gitopsv1alpha1.GeneratorOptions{
 				Name:           "test-component",
@@ -540,7 +554,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			err := generator.CloneGenerateAndPush(outputPath, repo, tt.component, tt.fs, "main", "/", true)
+			err := generator.CloneGenerateAndPush(outputPath, tt.repo, tt.component, tt.fs, "main", "/", true)
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)
@@ -700,7 +714,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					Args:    []string{"checkout", "-b", "main"},
 				},
 			},
-			wantErrString: "failed to checkout branch \"main\" in \"/fake/path/test-application\" \"test output1\": Permission denied",
+			wantErrString: "failed to checkout branch \"main\" in repository \"/fake/path/test-application\" \"test output1\": Permission denied",
 		},
 		{
 			name:      "Git switch failure, git checkout success",
@@ -901,7 +915,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					Args:    []string{"commit", "-m", fmt.Sprintf("Generate %s environment overlays for component %s", environmentName, componentName)},
 				},
 			},
-			wantErrString: "failed to commit files to repository in \"/fake/path/test-application\" \"test output1\": Fatal error",
+			wantErrString: "failed to commit files to repository \"/fake/path/test-application\" \"test output1\": Fatal error",
 		},
 		{
 			name:      "git push failure",
@@ -961,7 +975,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					Args:    []string{"push", "origin", "main"},
 				},
 			},
-			wantErrString: fmt.Sprintf("failed push remote to repository \"%s\" \"test output1\": Fatal error", repo),
+			wantErrString: fmt.Sprintf("failed to push remote to repository \"%s\" \"test output1\": Fatal error", repo),
 		},
 		{
 			name:            "gitops generate failure",
@@ -1152,7 +1166,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					Args:    []string{"checkout", "-b", "main"},
 				},
 			},
-			wantErrString: "failed to checkout branch \"main\" in \"/fake/path/test-component\" \"test output1\": Permission denied",
+			wantErrString: "failed to checkout branch \"main\" in repository \"/fake/path/test-component\" \"test output1\": Permission denied",
 		},
 		{
 			name:      "Git switch failure, git checkout success",
@@ -1399,7 +1413,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					Args:    []string{"commit", "-m", fmt.Sprintf("Removed component %s", componentName)},
 				},
 			},
-			wantErrString: "failed to commit files to repository in \"/fake/path/test-component\" \"test output1\": Fatal error",
+			wantErrString: "failed to commit files to repository \"/fake/path/test-component\" \"test output1\": Fatal error",
 		},
 		{
 			name:      "git push failure",
@@ -1462,7 +1476,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					Args:    []string{"push", "origin", "main"},
 				},
 			},
-			wantErrString: fmt.Sprintf("failed push remote to repository \"%s\" \"test output1\": Fatal error", repo),
+			wantErrString: fmt.Sprintf("failed to push remote to repository \"%s\" \"test output1\": Fatal error", repo),
 		},
 	}
 
@@ -1629,7 +1643,7 @@ func TestRemoveComponent(t *testing.T) {
 					Args:    []string{"checkout", "-b", "main"},
 				},
 			},
-			wantCloneErrString: "failed to checkout branch \"main\" in \"/fake/path/test-component\" \"test output1\": Permission denied",
+			wantCloneErrString: "failed to checkout branch \"main\" in repository \"/fake/path/test-component\" \"test output1\": Permission denied",
 		},
 		{
 			name:      "Git switch failure, git checkout success",
@@ -1876,7 +1890,7 @@ func TestRemoveComponent(t *testing.T) {
 					Args:    []string{"commit", "-m", fmt.Sprintf("Removed component %s", componentName)},
 				},
 			},
-			wantPushErrString: "failed to commit files to repository in \"/fake/path/test-component\" \"test output1\": Fatal error",
+			wantPushErrString: "failed to commit files to repository \"/fake/path/test-component\" \"test output1\": Fatal error",
 		},
 		{
 			name:      "git push failure",
@@ -1939,7 +1953,7 @@ func TestRemoveComponent(t *testing.T) {
 					Args:    []string{"push", "origin", "main"},
 				},
 			},
-			wantPushErrString: fmt.Sprintf("failed push remote to repository \"%s\" \"test output1\": Fatal error", repo),
+			wantPushErrString: fmt.Sprintf("failed to push remote to repository \"%s\" \"test output1\": Fatal error", repo),
 		},
 	}
 
@@ -2047,10 +2061,8 @@ func TestGenerateAndPush(t *testing.T) {
 	outputPath := "/fake/path"
 	component := gitopsv1alpha1.GeneratorOptions{
 		ContainerImage: "testimage:latest",
-		GitSource: &gitopsv1alpha1.GitSource{
-			URL: repo,
-		},
-		TargetPort: 5000,
+		GitSource:      &gitopsv1alpha1.GitSource{},
+		TargetPort:     5000,
 	}
 	component.Name = "test-component"
 	fs := ioutils.NewMemoryFilesystem()
@@ -2061,6 +2073,8 @@ func TestGenerateAndPush(t *testing.T) {
 		component     gitopsv1alpha1.GeneratorOptions
 		errors        *testutils.ErrorStack
 		outputs       [][]byte
+		doPush        bool
+		repo          string
 		want          []testutils.Execution
 		wantErrString string
 	}{
@@ -2068,8 +2082,30 @@ func TestGenerateAndPush(t *testing.T) {
 			name:      "No errors. GenerateAndPush test with no push",
 			fs:        fs,
 			component: component,
+			doPush:    false,
+			repo:      "https://github.com/testing/testing.git",
 			errors:    &testutils.ErrorStack{},
 			want:      []testutils.Execution{},
+		},
+		{
+			name:          "GenerateAndPush test with push.  Client access error",
+			fs:            fs,
+			component:     component,
+			doPush:        true,
+			repo:          "https://xyz/testing/testing.git",
+			errors:        &testutils.ErrorStack{},
+			want:          []testutils.Execution{},
+			wantErrString: "failed to create a client to access \"https://xyz/testing/testing.git\": unable to identify driver from hostname: xyz",
+		},
+		{
+			name:          "GenerateAndPush test with push.  Unauthorized user error",
+			fs:            fs,
+			component:     component,
+			doPush:        true,
+			repo:          "https://github.com/testing/testing.git",
+			errors:        &testutils.ErrorStack{},
+			want:          []testutils.Execution{},
+			wantErrString: "failed to get the user with their auth token: Unauthorized",
 		},
 	}
 
@@ -2077,9 +2113,9 @@ func TestGenerateAndPush(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			outputStack := testutils.NewOutputs(tt.outputs...)
 			executedCmds := []testutils.Execution{}
-
+			component.GitSource.URL = tt.repo
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
-			err := generator.GenerateAndPush(outputPath, repo, tt.component, tt.fs, "main", false, "KAM CLI")
+			err := generator.GenerateAndPush(outputPath, repo, tt.component, tt.fs, "main", tt.doPush, "KAM CLI")
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)
@@ -2185,7 +2221,7 @@ func createEmptyGitRepository(repoPath string) error {
 func getCommitIDFromDotGit(repoPath string) (string, error) {
 	fs := ioutils.NewFilesystem()
 	var fileBytes []byte
-	fileBytes, err := fs.ReadFile(filepath.Join(repoPath, ".git", "refs", "heads", "master"))
+	fileBytes, err := fs.ReadFile(filepath.Join(repoPath, ".git", "refs", "heads", "main"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,6 +38,7 @@ func ValidateRemote(remote string) error {
 	return invalidRemoteMsg
 }
 
+/* #nosec G101 -- regex for remote url segment that can contain a token.  This is not a hardcoded token*/
 const tokenRegex = `(https:\/\/)(\w+)@`
 
 // SanitizeErrorMessage takes in a given error message and returns a new, sanitized error with things like tokens removed

--- a/pkg/util/utilFuzz_test.go
+++ b/pkg/util/utilFuzz_test.go
@@ -1,0 +1,43 @@
+/* Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// run this test locally using go test -fuzz={FuzzTestName} in the test directory
+
+func FuzzSanitizeErrorMessage(f *testing.F) {
+	testcases := []string{"https://@github.com/fake/repo", "https://ghp_fj3492danj924@github.com/fake/repo", "ghp_A8jk2jsofle@github.com", "ghu_islaj29falkjsdf@github.com", "29IwharlkP1234fjiso@github.com"}
+	for _, tc := range testcases {
+		f.Add(tc) // Use f.Add to provide a seed corpus
+	}
+	reg, err := regexp.Compile(tokenRegex)
+	f.Fuzz(func(t *testing.T, errMsg string) {
+		//sanitize message
+		sanitizedMsg := SanitizeErrorMessage(errors.New(errMsg))
+		//verify message has been sanitized
+		if err == nil && reg.MatchString(errMsg) {
+			if !strings.Contains(sanitizedMsg.Error(), "<TOKEN>") {
+				t.Errorf("String was not sanitized %q ", sanitizedMsg)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->

- Creates a set of custom gitops error messages so they are sanitized before returning to the client
- Update similarly worded error messages so they are consistent and can be reused by the same custom error message
- Update unit tests
- Added a new Fuzz test for the util function 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-133

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
