### PR TITLE
Updating base generator based on YAML files

### DIFF
--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -29,6 +29,7 @@ type GitSource struct {
 	URL string `json:"url"`
 }
 
+// KubernetesResources define the list of Kubernetes resources
 type KubernetesResources struct {
 	Deployments []appsv1.Deployment
 	Services    []corev1.Service

--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -17,13 +17,24 @@ limitations under the License.
 package v1alpha1
 
 import (
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // GitSource describes the Component source
 type GitSource struct {
 	// If importing from git, the repository to create the component from
 	URL string `json:"url"`
+}
+
+type KubernetesResources struct {
+	Deployments []appsv1.Deployment
+	Services    []corev1.Service
+	Routes      []routev1.Route
+	Ingresses   []networkingv1.Ingress
+	Others      []interface{}
 }
 
 // GeneratorOptions - This captures the options for generating the component's GitOps resources for a component of an
@@ -72,4 +83,7 @@ type GeneratorOptions struct {
 
 	// The container image to build or create the component from
 	ContainerImage string `json:"containerImage,omitempty"`
+
+	// KubernetesResources to be used instead of generating the Kubernetes resources from a component
+	KubernetesResources KubernetesResources `json:"kuberntesResources,omitempty"`
 }

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -30,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	yaml "github.com/redhat-developer/gitops-generator/pkg/yaml"
-
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -47,7 +45,7 @@ var CreatedBy = "application-service"
 
 // Generate takes in a given Component CR and
 // spits out a deployment, service, and route file to disk
-func Generate(log logr.Logger, fs afero.Afero, gitOpsFolder string, outputFolder string, component gitopsv1alpha1.GeneratorOptions) error {
+func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, component gitopsv1alpha1.GeneratorOptions) error {
 
 	var deployment *appsv1.Deployment
 	if len(component.KubernetesResources.Deployments) == 0 {

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	gitopsv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-generator/pkg/testutils"
 	"github.com/redhat-developer/gitops-generator/pkg/util"
@@ -1488,7 +1489,7 @@ func TestGitRemoveComponent(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			if err := Generate(fs, repoPath, componentBasePath, tt.component); err != nil {
+			if err := Generate(logr.Logger{}, fs, repoPath, componentBasePath, tt.component); err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
 			}
@@ -1964,7 +1965,7 @@ func TestRemoveComponent(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			if err := Generate(fs, repoPath, componentBasePath, tt.component); err != nil {
+			if err := Generate(logr.Logger{}, fs, repoPath, componentBasePath, tt.component); err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
 			}

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -23,13 +23,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	gitopsv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-generator/pkg/testutils"
 	"github.com/redhat-developer/gitops-generator/pkg/util"
 	"github.com/redhat-developer/gitops-generator/pkg/util/ioutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var originalExecute = execute
@@ -68,6 +73,111 @@ func TestCloneGenerateAndPush(t *testing.T) {
 			fs:        fs,
 			component: component,
 			errors:    &testutils.ErrorStack{},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+				[]byte("test output3"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", filepath.Join("components", componentName, "base")},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"commit", "-m", fmt.Sprintf("Generate GitOps base resources for component %s", componentName)},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"push", "origin", "main"},
+				},
+			},
+		},
+		{
+			name: "No errors with Kubernetes Resources provided",
+			repo: repo,
+			fs:   fs,
+			component: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+				KubernetesResources: gitopsv1alpha1.KubernetesResources{
+					Deployments: []appsv1.Deployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deployment1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deployment2",
+							},
+						},
+					},
+					Services: []corev1.Service{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "service1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "service2",
+							},
+						},
+					},
+					Routes: []routev1.Route{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "route1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "route2",
+							},
+						},
+					},
+					Ingresses: []networkingv1.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "ingress1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "ingress2",
+							},
+						},
+					},
+				},
+			},
+			errors: &testutils.ErrorStack{},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
@@ -1489,7 +1599,7 @@ func TestGitRemoveComponent(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			if err := Generate(logr.Logger{}, fs, repoPath, componentBasePath, tt.component); err != nil {
+			if err := Generate(fs, repoPath, componentBasePath, tt.component); err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
 			}
@@ -1965,7 +2075,7 @@ func TestRemoveComponent(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			if err := Generate(logr.Logger{}, fs, repoPath, componentBasePath, tt.component); err != nil {
+			if err := Generate(fs, repoPath, componentBasePath, tt.component); err != nil {
 				t.Errorf("unexpected error %v", err)
 				return
 			}

--- a/pkg/yaml/resources.go
+++ b/pkg/yaml/resources.go
@@ -80,7 +80,6 @@ func MarshalOutput(out io.Writer, output interface{}) error {
 			data = append(data, nestedData...)
 		}
 	} else {
-
 		data, err = yaml.Marshal(output)
 		if err != nil {
 			return fmt.Errorf("failed to marshal data: %v", err)

--- a/pkg/yaml/resources.go
+++ b/pkg/yaml/resources.go
@@ -65,10 +65,28 @@ func MarshalItemToFile(fs afero.Fs, filename string, item interface{}) error {
 
 // MarshalOutput marshal output to given writer
 func MarshalOutput(out io.Writer, output interface{}) error {
-	data, err := yaml.Marshal(output)
-	if err != nil {
-		return fmt.Errorf("failed to marshal data: %v", err)
+
+	separator := []byte("---\n")
+	var data []byte
+	var err error
+
+	if v, ok := output.([]interface{}); ok {
+		for _, o := range v {
+			nestedData, err := yaml.Marshal(o)
+			if err != nil {
+				return fmt.Errorf("failed to marshal data: %v", err)
+			}
+			nestedData = append(nestedData, separator...)
+			data = append(data, nestedData...)
+		}
+	} else {
+
+		data, err = yaml.Marshal(output)
+		if err != nil {
+			return fmt.Errorf("failed to marshal data: %v", err)
+		}
 	}
+
 	_, err = fmt.Fprintf(out, "%s", data)
 	if err != nil {
 		return fmt.Errorf("failed to write data: %v", err)

--- a/pkg/yaml/resources_test.go
+++ b/pkg/yaml/resources_test.go
@@ -200,6 +200,13 @@ func TestMarshalItemToFileAndUnMarshalItemFromFile(t *testing.T) {
 func TestMarshallOutput(t *testing.T) {
 	fs := ioutils.NewMemoryFilesystem()
 	readOnlyFs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+	str := []string{"first", "second"}
+	other := make([]interface{}, len(str))
+	for i, s := range str {
+		other[i] = s
+	}
+	otherInvalid := make([]interface{}, 1)
+	otherInvalid[0] = make(chan int)
 
 	f, _ := fs.Create("/test/file")
 	readonlyF, _ := readOnlyFs.Open("/")
@@ -216,9 +223,21 @@ func TestMarshallOutput(t *testing.T) {
 			errMsg: "",
 		},
 		{
+			name:   "Array resource",
+			f:      f,
+			item:   other,
+			errMsg: "",
+		},
+		{
 			name:   "Invalid resource",
 			f:      f,
 			item:   make(chan int),
+			errMsg: "failed to marshal data: error marshaling into JSON: json: unsupported type: chan int",
+		},
+		{
+			name:   "Array invalid resource",
+			f:      f,
+			item:   otherInvalid,
 			errMsg: "failed to marshal data: error marshaling into JSON: json: unsupported type: chan int",
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR updates the generator logic for the base dir. When Kubernetes resources are provided during a call to Generate; the Generate logic should use the resources provided and create the base dir with it. 

If the Kubernetes resources are not provided, fallback to generating the Kubernetes resources based on the options data.

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->


### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
Unit tests should pass