### PR TITLE
[DEVHAS-235] Trim generated route CR name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 require (
 	code.gitea.io/sdk/gitea v0.14.0 // indirect
 	github.com/bluekeyes/go-gitdiff v0.4.0 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -28,6 +29,8 @@ require (
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluekeyes/go-gitdiff v0.4.0 h1:Q3qUnQ5cv27vG6ywUTiSQUobRYRcQIBs8KVGKojLg9I=
 github.com/bluekeyes/go-gitdiff v0.4.0/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iCdvGXBcEzHGbM=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -192,6 +194,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -23,6 +23,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-developer/gitops-generator/pkg/resources"
+	"github.com/redhat-developer/gitops-generator/pkg/util"
 	"github.com/spf13/afero"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -362,6 +363,12 @@ func generateService(options gitopsv1alpha1.GeneratorOptions) *corev1.Service {
 }
 
 func generateRoute(options gitopsv1alpha1.GeneratorOptions) *routev1.Route {
+	// Trim the generated route name to under 30 characters (plus a few random characters for uniqueness)
+	// To ensure issues where the generated hostname (componentName-namespace) is too long
+	routeName := options.Name
+	if len(routeName) >= 30 {
+		routeName = routeName[0:25] + util.GetRandomString(4, true)
+	}
 	k8sLabels := generateK8sLabels(options)
 	weight := int32(100)
 	route := routev1.Route{
@@ -370,7 +377,7 @@ func generateRoute(options gitopsv1alpha1.GeneratorOptions) *routev1.Route {
 			APIVersion: "route.openshift.io/v1",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      options.Name,
+			Name:      routeName,
 			Namespace: options.Namespace,
 			Labels:    k8sLabels,
 		},

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -18,6 +18,7 @@ package gitops
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/redhat-developer/gitops-generator/pkg/testutils"
@@ -591,12 +592,71 @@ func TestGenerateRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Generated route with trimmed CR name",
+			component: gitopsv1alpha1.GeneratorOptions{
+				Name:        "some-longer-component-name-test-string",
+				Namespace:   namespace,
+				Application: applicationName,
+				TargetPort:  5000,
+				K8sLabels: map[string]string{
+					"app.kubernetes.io/name":       "some-longer-component-name-test-string",
+					"app.kubernetes.io/instance":   "ComponentCRName",
+					"app.kubernetes.io/part-of":    applicationName,
+					"app.kubernetes.io/managed-by": "kustomize",
+					"app.kubernetes.io/created-by": "GitOps Generator Test",
+				},
+				Route: "example.com",
+			},
+			wantRoute: routev1.Route{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Route",
+					APIVersion: "route.openshift.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "some-longer-component-name-test-string",
+						"app.kubernetes.io/instance":   "ComponentCRName",
+						"app.kubernetes.io/part-of":    applicationName,
+						"app.kubernetes.io/managed-by": "kustomize",
+						"app.kubernetes.io/created-by": "GitOps Generator Test",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "example.com",
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromInt(5000),
+					},
+					TLS: &routev1.TLSConfig{
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+						Termination:                   routev1.TLSTerminationEdge,
+					},
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   "some-longer-component-name-test-string",
+						Weight: &weight,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			generatedRoute := generateRoute(tt.component)
+			if len(generatedRoute.Name) > 30 {
+				t.Errorf("TestGenerateRoute() error: expected CR name of length 30, got %v", len(generatedRoute.Name))
+			}
 
+			if tt.name == "Generated route with trimmed CR name" {
+				trimmedComponentName := "some-longer-component-nam"
+				if !strings.Contains(generatedRoute.Name, trimmedComponentName) {
+					t.Errorf("TestGenerateRoute() error: expected component CR name to contain %v got %v", tt.wantRoute, generatedRoute)
+				}
+
+				tt.wantRoute.Name = generatedRoute.Name
+			}
 			if !reflect.DeepEqual(*generatedRoute, tt.wantRoute) {
 				t.Errorf("TestGenerateRoute() error: expected %v got %v", tt.wantRoute, generatedRoute)
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"errors"
+	"math/rand"
 	"net/url"
 	"regexp"
 	"strings"
@@ -39,7 +40,10 @@ func ValidateRemote(remote string) error {
 }
 
 /* #nosec G101 -- regex for remote url segment that can contain a token.  This is not a hardcoded token*/
-const tokenRegex = `(https:\/\/)(\w+)@`
+const (
+	tokenRegex  = `(https:\/\/)(\w+)@`
+	schemaBytes = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+)
 
 // SanitizeErrorMessage takes in a given error message and returns a new, sanitized error with things like tokens removed
 func SanitizeErrorMessage(err error) error {
@@ -56,4 +60,19 @@ func SanitizeErrorMessage(err error) error {
 	}
 
 	return errors.New(newErrMsg)
+}
+
+// GetRandomString returns a random string which is n characters long.
+// If lower is set to true a lower case string is returned.
+func GetRandomString(n int, lower bool) string {
+	b := make([]byte, n)
+	for i := range b {
+		/* #nosec G404 -- not used for cryptographic purposes*/
+		b[i] = schemaBytes[rand.Intn(len(schemaBytes)-1)]
+	}
+	randomString := string(b)
+	if lower {
+		randomString = strings.ToLower(randomString)
+	}
+	return randomString
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -16,7 +16,10 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestValidateRemoteURL(t *testing.T) {
@@ -103,6 +106,38 @@ func TestSanitizeErrorMessage(t *testing.T) {
 			if sanitizedError.Error() != tt.want.Error() {
 				t.Errorf("SanitizeName() error: expected %v got %v", tt.want, sanitizedError)
 			}
+		})
+	}
+}
+
+func TestGetRandomString(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+		lower  bool
+	}{
+		{
+			name:   "all lower case string",
+			length: 5,
+			lower:  true,
+		},
+		{
+			name:   "contain upper case string",
+			length: 10,
+			lower:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotString := GetRandomString(tt.length, tt.lower)
+			assert.Equal(t, tt.length, len(gotString), "the values should match")
+
+			if tt.lower == true {
+				assert.Equal(t, strings.ToLower(gotString), gotString, "the values should match")
+			}
+
+			gotString2 := GetRandomString(tt.length, tt.lower)
+			assert.NotEqual(t, gotString, gotString2, "the two random string should not be the same")
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
This PR updates the Route generation logic to ensure the CR name is no more than 30 characters. To ensure that the resultant generated hostname is valid.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-235

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
