### PR TITLE
Attempt a git pull before a git commit and push

### DIFF
--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -75,15 +75,26 @@ func (e *GitBranchError) Error() string {
 	return util.SanitizeErrorMessage(fmt.Errorf("failed to %s branch %q in repository %q %q: %s", e.cmdType, e.branch, e.repoPath, string(e.cmdResult), e.err)).Error()
 }
 
-// GitFetchError is used to construct custom errors related to git fetch failures
-type GitFetchError struct {
+// GitPullError is used to construct custom errors related to git pull failures
+type GitPullError struct {
 	remote    string
 	cmdResult string
 	err       error
 }
 
-func (e *GitFetchError) Error() string {
-	return util.SanitizeErrorMessage(fmt.Errorf("failed to fetch from remote %q %q: %s", e.remote, string(e.cmdResult), e.err)).Error()
+func (e *GitPullError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to pull from remote %q %q: %s", e.remote, string(e.cmdResult), e.err)).Error()
+}
+
+// GitLsRemoteError is used to construct custom errors related to git ls-remote failures
+type GitLsRemoteError struct {
+	remote    string
+	cmdResult string
+	err       error
+}
+
+func (e *GitLsRemoteError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to list git remotes for remote %q %q: %s", e.remote, string(e.cmdResult), e.err)).Error()
 }
 
 type GitGenResourcesAndOverlaysError struct {

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -75,6 +75,17 @@ func (e *GitBranchError) Error() string {
 	return util.SanitizeErrorMessage(fmt.Errorf("failed to %s branch %q in repository %q %q: %s", e.cmdType, e.branch, e.repoPath, string(e.cmdResult), e.err)).Error()
 }
 
+// GitFetchError is used to construct custom errors related to git fetch failures
+type GitFetchError struct {
+	remote    string
+	cmdResult string
+	err       error
+}
+
+func (e *GitFetchError) Error() string {
+	return util.SanitizeErrorMessage(fmt.Errorf("failed to fetch from remote %q %q: %s", e.remote, string(e.cmdResult), e.err)).Error()
+}
+
 type GitGenResourcesAndOverlaysError struct {
 	path          string
 	componentName string

--- a/pkg/gitops.go
+++ b/pkg/gitops.go
@@ -116,6 +116,11 @@ func (s Gen) CloneGenerateAndPush(outputPath string, remote string, options gito
 	gitopsFolder := filepath.Join(repoPath, context)
 	componentPath := filepath.Join(gitopsFolder, "components", componentName, "base")
 
+	// Fetch from remote
+	if out, err := execute(repoPath, GitCommand, "fetch"); err != nil {
+		return &GitFetchError{err: err, cmdResult: string(out), remote: remote}
+	}
+
 	// Checkout the specified branch
 	s.Log.V(6).Info(fmt.Sprintf("Checking out branch %s", branch))
 	if _, err := execute(repoPath, GitCommand, "switch", branch); err != nil {
@@ -322,6 +327,11 @@ func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote strin
 			return &GitCmdError{path: outputPath, cmdResult: string(out), err: err, cmdType: cloneRepo}
 		}
 
+		// Fetch from remote
+		if out, err := execute(repoPath, GitCommand, "fetch"); err != nil {
+			return &GitFetchError{err: err, cmdResult: string(out), remote: remote}
+		}
+
 		// Checkout the specified branch
 		if _, err := execute(repoPath, GitCommand, "switch", branch); err != nil {
 			if out, err := execute(repoPath, GitCommand, "checkout", "-b", branch); err != nil {
@@ -376,6 +386,12 @@ func (s Gen) CloneRepo(outputPath string, remote string, componentName string, b
 	if out, err := execute(outputPath, GitCommand, "clone", remote, componentName); err != nil {
 		return &GitCmdError{path: outputPath, cmdResult: string(out), err: err, cmdType: cloneRepo}
 	}
+
+	// Fetch from remote
+	if out, err := execute(repoPath, GitCommand, "fetch"); err != nil {
+		return &GitFetchError{err: err, cmdResult: string(out), remote: remote}
+	}
+
 	// Checkout the specified branch
 	if _, err := execute(repoPath, GitCommand, "switch", branch); err != nil {
 		if out, err := execute(repoPath, GitCommand, "checkout", "-b", branch); err != nil {

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -23,14 +23,13 @@ import (
 	"strings"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
 	gitopsv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-generator/pkg/testutils"
 	"github.com/redhat-developer/gitops-generator/pkg/util"
 	"github.com/redhat-developer/gitops-generator/pkg/util/ioutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-
-	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -45,6 +44,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 	outputPath := "/fake/path"
 	repoPath := "/fake/path/test-component"
 	componentName := "test-component"
+	branch := "main"
 	component := gitopsv1alpha1.GeneratorOptions{
 		ContainerImage: "testimage:latest",
 		GitSource: &gitopsv1alpha1.GitSource{
@@ -77,22 +77,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -113,6 +109,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -188,22 +194,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -224,6 +226,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -258,22 +270,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -294,6 +302,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -329,22 +347,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -365,6 +379,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -399,22 +423,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -435,6 +455,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -470,22 +500,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -506,6 +532,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -540,22 +576,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -576,6 +608,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -614,35 +656,6 @@ func TestCloneGenerateAndPush(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
-			name:      "Git fetch failure",
-			repo:      repo,
-			fs:        fs,
-			component: component,
-			errors: &testutils.ErrorStack{
-				Errors: []error{
-					errors.New("fetch error"),
-					nil,
-				},
-			},
-			outputs: [][]byte{
-				[]byte("test output1"),
-				[]byte("test output2"),
-			},
-			want: []testutils.Execution{
-				{
-					BaseDir: outputPath,
-					Command: "git",
-					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
-				},
-			},
-			wantErrString: "fetch error",
-		},
-		{
 			name:      "Git switch failure, git checkout failure",
 			repo:      repo,
 			fs:        fs,
@@ -652,25 +665,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -695,30 +701,25 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
 				[]byte("test output9"),
+				[]byte("test output10"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -748,6 +749,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
 					Args:    []string{"commit", "-m", fmt.Sprintf("Generate GitOps base resources for component %s", componentName)},
 				},
 				{
@@ -768,25 +779,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -812,7 +816,6 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -820,18 +823,12 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
-				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -863,7 +860,6 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -872,18 +868,12 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
-				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -909,14 +899,13 @@ func TestCloneGenerateAndPush(t *testing.T) {
 			wantErrString: "failed to check git diff in repository \"/fake/path/test-component\" \"test output1\": Permission Denied",
 		},
 		{
-			name:      "git commit failure",
+			name:      "Git ls remote failure",
 			repo:      repo,
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
 				Errors: []error{
-					errors.New("Fatal error"),
-					nil,
+					errors.New("ls error"),
 					nil,
 					nil,
 					nil,
@@ -931,18 +920,12 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
-				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -963,6 +946,141 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+			},
+			wantErrString: "ls error",
+		},
+		{
+			name:      "Git pull failure",
+			repo:      repo,
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("pull error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2 refs/heads/main"),
+				[]byte("test output3"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output6"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", "components/test-component/base"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+			},
+			wantErrString: "pull error",
+		},
+		{
+			name:      "git commit failure",
+			repo:      repo,
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("Fatal error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+				[]byte("test output3 refs/heads/main"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+				[]byte("test output8"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", "components/test-component/base"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -987,28 +1105,25 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repoWithToken, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1029,6 +1144,16 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repoWithToken, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1054,11 +1179,6 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1092,11 +1212,6 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
-					Args:    []string{"fetch"},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
 					Args:    []string{"switch", "main"},
 				},
 				{
@@ -1117,7 +1232,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			err := generator.CloneGenerateAndPush(outputPath, tt.repo, tt.component, tt.fs, "main", "/", true)
+			err := generator.CloneGenerateAndPush(outputPath, tt.repo, tt.component, tt.fs, branch, "/", true)
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)
@@ -1146,6 +1261,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 		Name:     componentName,
 		Replicas: 2,
 	}
+	branch := "main"
 	component.Name = "test-component"
 	fs := ioutils.NewMemoryFilesystem()
 	readOnlyFs := ioutils.NewReadOnlyFs()
@@ -1172,10 +1288,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1186,11 +1303,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1206,6 +1318,16 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1247,35 +1369,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
-			name:      "Git fetch failure",
-			fs:        fs,
-			component: component,
-			errors: &testutils.ErrorStack{
-				Errors: []error{
-					errors.New("fetch error"),
-					nil,
-				},
-			},
-			outputs: [][]byte{
-				[]byte("test output1"),
-				[]byte("test output2"),
-			},
-			want: []testutils.Execution{
-				{
-					BaseDir: outputPath,
-					Command: "git",
-					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
-				},
-			},
-			applicationName: applicationName,
-			wantErrString:   "fetch error",
-		},
-		{
 			name:      "Git switch failure, git checkout failure",
 			fs:        fs,
 			component: component,
@@ -1284,14 +1377,12 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1302,11 +1393,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1330,17 +1416,17 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 				[]byte("test output8"),
 			},
 			applicationName: applicationName,
@@ -1352,11 +1438,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1381,6 +1462,16 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
 					Args:    []string{"commit", "-m", fmt.Sprintf("Generate %s environment overlays for component %s", environmentName, componentName)},
 				},
 				{
@@ -1400,14 +1491,12 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					errors.New("Fatal error"),
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1418,11 +1507,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1447,7 +1531,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1455,7 +1538,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
-				[]byte("test output5"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1466,11 +1548,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1491,13 +1568,12 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 			wantErrString: "failed to check git diff in repository \"/fake/path/test-application\" \"test output1\": Permission Denied",
 		},
 		{
-			name:      "git commit failure",
+			name:      "Git ls remote failure",
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
 				Errors: []error{
-					errors.New("Fatal error"),
-					nil,
+					errors.New("ls error"),
 					nil,
 					nil,
 					nil,
@@ -1510,22 +1586,12 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
-				[]byte("test output6"),
 			},
-			applicationName: applicationName,
-			environmentName: environmentName,
-			imageName:       imageName,
-			namespace:       namespace,
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1541,6 +1607,131 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+			},
+			applicationName: applicationName,
+			wantErrString:   "ls error",
+		},
+		{
+			name:      "Git pull failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("pull error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2 refs/heads/main"),
+				[]byte("test output3"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+			},
+			applicationName: applicationName,
+			wantErrString:   "pull error",
+		},
+		{
+			name:      "git commit failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("Fatal error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+				[]byte("test output3 refs/heads/main"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+			},
+			applicationName: applicationName,
+			environmentName: environmentName,
+			imageName:       imageName,
+			namespace:       namespace,
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1563,15 +1754,17 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 				[]byte("test output7"),
 			},
 			applicationName: applicationName,
@@ -1587,11 +1780,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
-					Args:    []string{"fetch"},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
 					Args:    []string{"switch", "main"},
 				},
 				{
@@ -1603,6 +1791,16 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1635,11 +1833,6 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
-					Args:    []string{"fetch"},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
 					Args:    []string{"switch", "main"},
 				},
 			},
@@ -1655,7 +1848,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, tt.fs, "main", "/", true, generatedResources)
+			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, tt.fs, branch, "/", true, generatedResources)
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)
@@ -1693,6 +1886,7 @@ func TestGitRemoveComponent(t *testing.T) {
 	component.Name = "test-component"
 	fs := ioutils.NewMemoryFilesystem()
 	generator := NewGitopsGen()
+	branch := "main"
 
 	tests := []struct {
 		name          string
@@ -1712,22 +1906,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1748,6 +1938,16 @@ func TestGitRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1785,34 +1985,6 @@ func TestGitRemoveComponent(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
-			name:      "Git fetch failure",
-			fs:        fs,
-			component: component,
-			errors: &testutils.ErrorStack{
-				Errors: []error{
-					errors.New("fetch error"),
-					nil,
-				},
-			},
-			outputs: [][]byte{
-				[]byte("test output1"),
-				[]byte("test output2"),
-			},
-			want: []testutils.Execution{
-				{
-					BaseDir: outputPath,
-					Command: "git",
-					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
-				},
-			},
-			wantErrString: "fetch error",
-		},
-		{
 			name:      "Git switch failure, git checkout failure",
 			fs:        fs,
 			component: component,
@@ -1821,25 +1993,18 @@ func TestGitRemoveComponent(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1863,30 +2028,25 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
 				[]byte("test output9"),
+				[]byte("test output10"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1916,6 +2076,16 @@ func TestGitRemoveComponent(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
 					Args:    []string{"commit", "-m", fmt.Sprintf("Removed component %s", componentName)},
 				},
 				{
@@ -1935,25 +2105,18 @@ func TestGitRemoveComponent(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1978,7 +2141,6 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1986,18 +2148,12 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
-				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2028,7 +2184,6 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2037,18 +2192,12 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
-				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2074,13 +2223,12 @@ func TestGitRemoveComponent(t *testing.T) {
 			wantErrString: "failed to check git diff in repository \"/fake/path/test-component\" \"test output1\": Permission Denied",
 		},
 		{
-			name:      "git commit failure",
+			name:      "Git ls remote failure",
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
 				Errors: []error{
-					errors.New("Fatal error"),
-					nil,
+					errors.New("ls error"),
 					nil,
 					nil,
 					nil,
@@ -2095,18 +2243,12 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
-				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2127,6 +2269,139 @@ func TestGitRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+			},
+			wantErrString: "ls error",
+		},
+		{
+			name:      "Git pull failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("pull error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2 refs/heads/main"),
+				[]byte("test output3"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", componentPath},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+			},
+			wantErrString: "pull error",
+		},
+		{
+			name:      "git commit failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("Fatal error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+				[]byte("test output3 refs/heads/main"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+				[]byte("test output8"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", componentPath},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2150,16 +2425,18 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
@@ -2167,11 +2444,6 @@ func TestGitRemoveComponent(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2192,6 +2464,16 @@ func TestGitRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2221,7 +2503,7 @@ func TestGitRemoveComponent(t *testing.T) {
 				return
 			}
 
-			err := generator.GitRemoveComponent(outputPath, repo, tt.component.Name, "main", "/")
+			err := generator.GitRemoveComponent(outputPath, repo, tt.component.Name, branch, "/")
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)
@@ -2249,6 +2531,7 @@ func TestRemoveComponent(t *testing.T) {
 		},
 		TargetPort: 5000,
 	}
+	branch := "main"
 	component.Name = "test-component"
 	fs := ioutils.NewMemoryFilesystem()
 	generator := NewGitopsGen()
@@ -2272,22 +2555,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2308,6 +2587,16 @@ func TestRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2353,25 +2642,18 @@ func TestRemoveComponent(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2395,30 +2677,25 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
 				[]byte("test output9"),
+				[]byte("test output10"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2448,6 +2725,16 @@ func TestRemoveComponent(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
 					Args:    []string{"commit", "-m", fmt.Sprintf("Removed component %s", componentName)},
 				},
 				{
@@ -2467,25 +2754,18 @@ func TestRemoveComponent(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2510,7 +2790,6 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2518,18 +2797,12 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
-				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2560,7 +2833,6 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
-					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2569,18 +2841,12 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
-				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2606,13 +2872,12 @@ func TestRemoveComponent(t *testing.T) {
 			wantPushErrString: "failed to check git diff in repository \"/fake/path/test-component\" \"test output1\": Permission Denied",
 		},
 		{
-			name:      "git commit failure",
+			name:      "git ls remote failure",
 			fs:        fs,
 			component: component,
 			errors: &testutils.ErrorStack{
 				Errors: []error{
-					errors.New("Fatal error"),
-					nil,
+					errors.New("ls error"),
 					nil,
 					nil,
 					nil,
@@ -2627,18 +2892,12 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
-				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2659,6 +2918,139 @@ func TestRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+			},
+			wantPushErrString: "ls error",
+		},
+		{
+			name:      "git pull failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("pull error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2 refs/heads/main"),
+				[]byte("test output3"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", componentPath},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
+				},
+			},
+			wantPushErrString: "pull error",
+		},
+		{
+			name:      "git commit failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("Fatal error"),
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+				[]byte("test output3 refs/heads/main"),
+				[]byte("test output4"),
+				[]byte("test output5"),
+				[]byte("test output6"),
+				[]byte("test output7"),
+				[]byte("test output8"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"switch", "main"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "rm",
+					Args:    []string{"-rf", componentPath},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"add", "."},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2682,28 +3074,25 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
-				[]byte("test output4"),
+				[]byte("test output4 refs/heads/main"),
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
-				},
-				{
-					BaseDir: repoPath,
-					Command: "git",
-					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2724,6 +3113,16 @@ func TestRemoveComponent(t *testing.T) {
 					BaseDir: repoPath,
 					Command: "git",
 					Args:    []string{"--no-pager", "diff", "--cached"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"ls-remote", "--heads", repo, branch},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"pull"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2752,7 +3151,7 @@ func TestRemoveComponent(t *testing.T) {
 				return
 			}
 
-			err := generator.CloneRepo(outputPath, repo, tt.component.Name, "main")
+			err := generator.CloneRepo(outputPath, repo, tt.component.Name, branch)
 
 			if tt.wantCloneErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantCloneErrString, err)

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -81,12 +81,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -186,12 +192,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -250,12 +262,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -315,12 +333,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -379,12 +403,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -444,12 +474,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -508,12 +544,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -572,6 +614,35 @@ func TestCloneGenerateAndPush(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
+			name:      "Git fetch failure",
+			repo:      repo,
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("fetch error"),
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
+				},
+			},
+			wantErrString: "fetch error",
+		},
+		{
 			name:      "Git switch failure, git checkout failure",
 			repo:      repo,
 			fs:        fs,
@@ -581,18 +652,25 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -617,6 +695,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -628,12 +707,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -683,18 +768,25 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -720,6 +812,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -727,12 +820,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
+				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -764,6 +863,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -772,12 +872,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
+				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -815,6 +921,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -824,12 +931,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -873,6 +986,7 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -883,12 +997,18 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repoWithToken, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -938,6 +1058,11 @@ func TestCloneGenerateAndPush(t *testing.T) {
 				{
 					BaseDir: repoPath,
 					Command: "git",
+					Args:    []string{"fetch"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
 					Args:    []string{"switch", "main"},
 				},
 				{
@@ -963,6 +1088,11 @@ func TestCloneGenerateAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, "test-component"},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1045,6 +1175,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1055,6 +1186,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1111,6 +1247,35 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
+			name:      "Git fetch failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("fetch error"),
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
+				},
+			},
+			applicationName: applicationName,
+			wantErrString:   "fetch error",
+		},
+		{
 			name:      "Git switch failure, git checkout failure",
 			fs:        fs,
 			component: component,
@@ -1119,12 +1284,14 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1135,6 +1302,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1158,6 +1330,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1168,6 +1341,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1178,6 +1352,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1221,12 +1400,14 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					errors.New("Fatal error"),
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1237,6 +1418,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1261,6 +1447,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1268,6 +1455,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
+				[]byte("test output5"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1278,6 +1466,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1308,6 +1501,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1316,6 +1510,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
+				[]byte("test output6"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1326,6 +1521,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1362,6 +1562,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1371,6 +1572,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 			},
 			applicationName: applicationName,
 			environmentName: environmentName,
@@ -1381,6 +1583,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1424,6 +1631,11 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, applicationName},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1504,12 +1716,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1567,6 +1785,34 @@ func TestGitRemoveComponent(t *testing.T) {
 			wantErrString: "test error",
 		},
 		{
+			name:      "Git fetch failure",
+			fs:        fs,
+			component: component,
+			errors: &testutils.ErrorStack{
+				Errors: []error{
+					errors.New("fetch error"),
+					nil,
+				},
+			},
+			outputs: [][]byte{
+				[]byte("test output1"),
+				[]byte("test output2"),
+			},
+			want: []testutils.Execution{
+				{
+					BaseDir: outputPath,
+					Command: "git",
+					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
+				},
+			},
+			wantErrString: "fetch error",
+		},
+		{
 			name:      "Git switch failure, git checkout failure",
 			fs:        fs,
 			component: component,
@@ -1575,18 +1821,25 @@ func TestGitRemoveComponent(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1610,6 +1863,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1621,12 +1875,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1675,18 +1935,25 @@ func TestGitRemoveComponent(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1711,6 +1978,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1718,12 +1986,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
+				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1754,6 +2028,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1762,12 +2037,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
+				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1804,6 +2085,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1813,12 +2095,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1861,6 +2149,7 @@ func TestGitRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -1871,12 +2160,18 @@ func TestGitRemoveComponent(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -1981,12 +2276,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2052,18 +2353,25 @@ func TestRemoveComponent(t *testing.T) {
 					errors.New("Permission denied"),
 					errors.New("Fatal error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2087,6 +2395,7 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					errors.New("test error"),
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2098,12 +2407,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output6"),
 				[]byte("test output7"),
 				[]byte("test output8"),
+				[]byte("test output9"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2152,18 +2467,25 @@ func TestRemoveComponent(t *testing.T) {
 					errors.New("Permission Denied"),
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
 				[]byte("test output1"),
 				[]byte("test output2"),
 				[]byte("test output3"),
+				[]byte("test output4"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2188,6 +2510,7 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2195,12 +2518,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output2"),
 				[]byte("test output3"),
 				[]byte("test output4"),
+				[]byte("test output5"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2231,6 +2560,7 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2239,12 +2569,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output3"),
 				[]byte("test output4"),
 				[]byte("test output5"),
+				[]byte("test output6"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2281,6 +2617,7 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2290,12 +2627,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output4"),
 				[]byte("test output5"),
 				[]byte("test output6"),
+				[]byte("test output7"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,
@@ -2338,6 +2681,7 @@ func TestRemoveComponent(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				},
 			},
 			outputs: [][]byte{
@@ -2348,12 +2692,18 @@ func TestRemoveComponent(t *testing.T) {
 				[]byte("test output5"),
 				[]byte("test output6"),
 				[]byte("test output7"),
+				[]byte("test output8"),
 			},
 			want: []testutils.Execution{
 				{
 					BaseDir: outputPath,
 					Command: "git",
 					Args:    []string{"clone", repo, component.Name},
+				},
+				{
+					BaseDir: repoPath,
+					Command: "git",
+					Args:    []string{"fetch"},
 				},
 				{
 					BaseDir: repoPath,


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
Pulls from the remote before pushing.
This is done because sometimes during the process of gitops generation, a commit might have already taken place in the remote and in such circumstances, a git push will fail. A git pull allows us to fetch the latest remote changes before doing a git push

```
MacBook-Pro:application-sample-lK5Sb-rise-complete maysun$ git push origin main
To github.com:redhat-appstudio-appdata/application-sample-lK5Sb-rise-complete.git
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'git@github.com:redhat-appstudio-appdata/application-sample-lK5Sb-rise-complete.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
MacBook-Pro:application-sample-lK5Sb-rise-complete maysun$ git pull
remote: Enumerating objects: 17, done.
remote: Counting objects: 100% (17/17), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 12 (delta 4), reused 12 (delta 4), pack-reused 0
Unpacking objects: 100% (12/12), done.
From github.com:redhat-appstudio-appdata/application-sample-lK5Sb-rise-complete
   32a7c07..d2bddfc  main       -> origin/main
Merge made by the 'recursive' strategy.
 components/component-sample/base/deployment.yaml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
MacBook-Pro:application-sample-lK5Sb-rise-complete maysun$ git push origin main
Enumerating objects: 9, done.
Counting objects: 100% (8/8), done.
Delta compression using up to 12 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (5/5), 644 bytes | 644.00 KiB/s, done.
Total 5 (delta 0), reused 0 (delta 0)
To github.com:redhat-appstudio-appdata/application-sample-lK5Sb-rise-complete.git
   d2bddfc..9a078c8  main -> main
```

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-218

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
- tests should pass
- consume this module locally in HAS go.mod to verify `replace github.com/redhat-developer/gitops-generator => /Users/maysun/dev/redhat/gitops-generator`