### PR TITLE
[DEVHAS-258]preserve container name

### DIFF
--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -175,12 +175,7 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 		}
 
 		if len(originalDeploymentContent.Spec.Template.Spec.Containers) > 0 {
-			for _, container := range originalDeploymentContent.Spec.Template.Spec.Containers {
-				if container.Image == imageName {
-					containerName = container.Name
-					break
-				}
-			}
+			containerName = originalDeploymentContent.Spec.Template.Spec.Containers[0].Name
 		}
 	}
 

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -171,11 +171,16 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 	if DeploymentFileExist {
 		err = yaml.UnMarshalItemFromFile(fs, baseDeploymentFilePath, &originalDeploymentContent)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal items from %q: %v", filepath.Join(outputFolder, kustomizeFileName), err)
+			return fmt.Errorf("failed to unmarshal items from %q: %v", baseDeploymentFilePath, err)
 		}
 
 		if len(originalDeploymentContent.Spec.Template.Spec.Containers) > 0 {
-			containerName = originalDeploymentContent.Spec.Template.Spec.Containers[0].Name
+			for _, container := range originalDeploymentContent.Spec.Template.Spec.Containers {
+				if container.Image == imageName {
+					containerName = container.Name
+					break
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR reads in the base deployment.yaml file, and replace hard-coded container name and preserves the container name from the `overlays/deployment-patch.yaml`

Tested it works:
https://github.com/yangcao77/stephanie-app-yangcao-take-sit/blob/8670b8b55f55affbeff25c38cf63e962b7d0b6d8/components/devfile-sample-go-basic/overlays/staging/deployment-patch.yaml#L22

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-258

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
