### PR TITLE
[DEVHAS-304] Allow RevisionHistoryLimit to be set for generated deployments

### DIFF
--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -85,6 +85,10 @@ type GeneratorOptions struct {
 	// The container image to build or create the component from
 	ContainerImage string `json:"containerImage,omitempty"`
 
+	// RevisionHistoryLimit specifies the number of allowed revisions for generated deployments
+	// If unset, RevisionHistorylimit in the deployment spec(s) will not be set
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+
 	// KubernetesResources to be used instead of generating the Kubernetes resources from a component
 	KubernetesResources KubernetesResources `json:"kuberntesResources,omitempty"`
 }

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -228,6 +228,11 @@ func UpdateExistingKustomize(fs afero.Afero, outputFolder string) error {
 }
 
 func generateDeployment(component gitopsv1alpha1.GeneratorOptions) *appsv1.Deployment {
+	var revHistoryLimit *int32
+	if component.RevisionHistoryLimit != nil {
+		revHistoryLimit = component.RevisionHistoryLimit
+	}
+
 	var containerImage string
 	if component.ContainerImage != "" {
 		containerImage = component.ContainerImage
@@ -246,7 +251,8 @@ func generateDeployment(component gitopsv1alpha1.GeneratorOptions) *appsv1.Deplo
 			Labels:    k8sLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			Replicas:             &replicas,
+			RevisionHistoryLimit: revHistoryLimit,
 			Selector: &v1.LabelSelector{
 				MatchLabels: matchLabels,
 			},

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -251,8 +251,7 @@ func generateDeployment(component gitopsv1alpha1.GeneratorOptions) *appsv1.Deplo
 			Labels:    k8sLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:             &replicas,
-			RevisionHistoryLimit: revHistoryLimit,
+			Replicas: &replicas,
 			Selector: &v1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
@@ -311,6 +310,10 @@ func generateDeployment(component gitopsv1alpha1.GeneratorOptions) *appsv1.Deplo
 				},
 			},
 		}
+	}
+
+	if revHistoryLimit != nil {
+		deployment.Spec.RevisionHistoryLimit = revHistoryLimit
 	}
 
 	return &deployment

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -66,6 +66,8 @@ func TestGenerateDeployment(t *testing.T) {
 		"app.kubernetes.io/instance": componentName,
 	}
 
+	revisionHistoryLimit := int32(0)
+
 	tests := []struct {
 		name           string
 		component      gitopsv1alpha1.GeneratorOptions
@@ -135,6 +137,7 @@ func TestGenerateDeployment(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					},
 				},
+				RevisionHistoryLimit: &revisionHistoryLimit,
 			},
 			wantDeployment: appsv1.Deployment{
 				TypeMeta: v1.TypeMeta{
@@ -147,7 +150,8 @@ func TestGenerateDeployment(t *testing.T) {
 					Labels:    customK8slabels,
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &otherReplicas,
+					Replicas:             &otherReplicas,
+					RevisionHistoryLimit: &revisionHistoryLimit,
 					Selector: &v1.LabelSelector{
 						MatchLabels: matchLabels,
 					},


### PR DESCRIPTION
### What does this PR do?:
This PR updates the GitOps generator to add a new field to the `GeneratorOptions` - `RevisionHistoryLimit` - which when set, will set an alternate RevisionHistoryLimit in the spec of the generator Deployment resource.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/projects/DEVHAS/issues/DEVHAS-304

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
