### PR TITLE
Generate Route/Ingress in overlays

### DIFF
--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -91,4 +91,8 @@ type GeneratorOptions struct {
 
 	// KubernetesResources to be used instead of generating the Kubernetes resources from a component
 	KubernetesResources KubernetesResources `json:"kuberntesResources,omitempty"`
+
+	// IsKubernetesCluster tells us whether it is a Kubernetes or an OpenShift cluster
+	// Default is false, hence it is an OpenShift cluster
+	IsKubernetesCluster bool `json:"isKubernetesCluster,omitempty"`
 }

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/afero"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -37,8 +38,9 @@ const (
 	kustomizeFileName       = "kustomization.yaml"
 	deploymentFileName      = "deployment.yaml"
 	deploymentPatchFileName = "deployment-patch.yaml"
-	serviceFileName         = "service.yaml"
+	ingressFileName         = "ingress.yaml"
 	routeFileName           = "route.yaml"
+	serviceFileName         = "service.yaml"
 	otherFileName           = "other_resources.yaml"
 )
 
@@ -46,19 +48,19 @@ var CreatedBy = "application-service"
 
 // Generate takes in a given Component CR and
 // spits out a deployment, service, and route file to disk
-func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, component gitopsv1alpha1.GeneratorOptions) error {
+func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, options gitopsv1alpha1.GeneratorOptions) error {
 
 	var deployment *appsv1.Deployment
-	if len(component.KubernetesResources.Deployments) == 0 {
-		deployment = generateDeployment(component)
-	} else if len(component.KubernetesResources.Deployments) > 0 {
-		deployment, component.KubernetesResources.Deployments = &component.KubernetesResources.Deployments[0], component.KubernetesResources.Deployments[1:]
+	if len(options.KubernetesResources.Deployments) == 0 {
+		deployment = generateDeployment(options)
+	} else if len(options.KubernetesResources.Deployments) > 0 {
+		deployment, options.KubernetesResources.Deployments = &options.KubernetesResources.Deployments[0], options.KubernetesResources.Deployments[1:]
 		var otherDeployments []interface{}
-		for _, deployment := range component.KubernetesResources.Deployments {
+		for _, deployment := range options.KubernetesResources.Deployments {
 			otherDeployments = append(otherDeployments, deployment)
 		}
 
-		component.KubernetesResources.Others = append(component.KubernetesResources.Others, otherDeployments...)
+		options.KubernetesResources.Others = append(options.KubernetesResources.Others, otherDeployments...)
 	}
 
 	k := resources.Kustomization{
@@ -71,60 +73,55 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 	}
 
 	var service *corev1.Service
-	var route *routev1.Route
 
-	if len(component.KubernetesResources.Services) == 0 && component.TargetPort != 0 {
+	if len(options.KubernetesResources.Services) == 0 && options.TargetPort != 0 {
 		// If service was not provided, generate a service only if target port was provided
 		// If service was not provided and target port is 0, skip generation
-		service = generateService(component)
-	} else if len(component.KubernetesResources.Services) > 0 {
+		service = generateService(options)
+	} else if len(options.KubernetesResources.Services) > 0 {
 		// If a service was provided, get the first and append the rest to others
-		service, component.KubernetesResources.Services = &component.KubernetesResources.Services[0], component.KubernetesResources.Services[1:]
+		service, options.KubernetesResources.Services = &options.KubernetesResources.Services[0], options.KubernetesResources.Services[1:]
 
 		var otherServices []interface{}
-		for _, service := range component.KubernetesResources.Services {
+		for _, service := range options.KubernetesResources.Services {
 			otherServices = append(otherServices, service)
 		}
 
-		component.KubernetesResources.Others = append(component.KubernetesResources.Others, otherServices...)
+		options.KubernetesResources.Others = append(options.KubernetesResources.Others, otherServices...)
 	}
 
-	if len(component.KubernetesResources.Routes) == 0 && component.TargetPort != 0 {
-		// If route was not provided, generate a route only if target port was provided
-		// If route was not provided and target port is 0, skip generation
-		route = generateRoute(component)
-	} else if len(component.KubernetesResources.Routes) > 0 {
-		// If a route was provided, get the first and append the rest to others
-		route, component.KubernetesResources.Routes = &component.KubernetesResources.Routes[0], component.KubernetesResources.Routes[1:]
+	if len(options.KubernetesResources.Routes) > 0 {
+		// If Routes were provided, append Routes from second onwards to others
+		// The first Route is created in the overlays resource
 
 		var otherRoutes []interface{}
-		for _, route := range component.KubernetesResources.Routes {
+		for _, route := range options.KubernetesResources.Routes[1:] {
 			otherRoutes = append(otherRoutes, route)
 		}
 
-		component.KubernetesResources.Others = append(component.KubernetesResources.Others, otherRoutes...)
+		options.KubernetesResources.Others = append(options.KubernetesResources.Others, otherRoutes...)
 	}
 
-	var otherIngresses []interface{}
-	for _, ingress := range component.KubernetesResources.Ingresses {
-		otherIngresses = append(otherIngresses, ingress)
-	}
+	if len(options.KubernetesResources.Ingresses) > 0 {
+		// If Ingresses were provided, append Ingresses from second onwards to others
+		// The first Ingress is created in the overlays resource
 
-	component.KubernetesResources.Others = append(component.KubernetesResources.Others, otherIngresses...)
+		var otherIngresses []interface{}
+		for _, ingress := range options.KubernetesResources.Ingresses[1:] {
+			otherIngresses = append(otherIngresses, ingress)
+		}
+
+		options.KubernetesResources.Others = append(options.KubernetesResources.Others, otherIngresses...)
+	}
 
 	if service != nil {
 		k.AddResources(serviceFileName)
 		resources[serviceFileName] = service
 	}
 
-	if route != nil {
-		k.AddResources(routeFileName)
-		resources[routeFileName] = route
-	}
-
-	if len(component.KubernetesResources.Others) > 0 {
+	if len(options.KubernetesResources.Others) > 0 {
 		k.AddResources(otherFileName)
-		resources[otherFileName] = component.KubernetesResources.Others
+		resources[otherFileName] = options.KubernetesResources.Others
 	}
 
 	resources[kustomizeFileName] = k
@@ -139,7 +136,7 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 }
 
 // GenerateOverlays generates the overlays director in an existing GitOps structure
-func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, options gitopsv1alpha1.GeneratorOptions, imageName, namespace string, componentGeneratedResources map[string][]string) error {
+func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, options gitopsv1alpha1.GeneratorOptions, imageName, namespace string, clusterInfo ClusterInfo, componentGeneratedResources map[string][]string) error {
 	kustomizeFileExist, err := fs.Exists(filepath.Join(outputFolder, kustomizeFileName))
 	if err != nil {
 		return err
@@ -162,6 +159,10 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 		Kind:       "Kustomization",
 	}
 
+	if componentGeneratedResources == nil {
+		componentGeneratedResources = make(map[string][]string)
+	}
+
 	var originalDeploymentContent appsv1.Deployment
 	baseDeploymentFilePath := filepath.Join(outputFolder, "../../base/", deploymentFileName)
 	DeploymentFileExist, err := fs.Exists(baseDeploymentFilePath)
@@ -182,20 +183,50 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 
 	deploymentPatch := generateDeploymentPatch(options, imageName, containerName, namespace)
 
+	resources := map[string]interface{}{
+		deploymentPatchFileName: deploymentPatch,
+	}
+
 	k.AddResources("../../base")
 	k.AddPatches(deploymentPatchFileName)
-	if componentGeneratedResources == nil {
-		componentGeneratedResources = make(map[string][]string)
-	}
 	componentGeneratedResources[options.Name] = append(componentGeneratedResources[options.Name], deploymentPatchFileName)
+
+	var route *routev1.Route
+	var ingress *networkingv1.Ingress
+
+	// Create an ingress if its a Kubernetes cluster, route if its an OpenShift cluster
+	if clusterInfo.IsKubernetesCluster {
+		if len(options.KubernetesResources.Ingresses) == 0 && options.TargetPort != 0 {
+			// If no Ingresses were provided and TargetPort is not 0, generate the Ingress
+			ingress = generateIngress(options, clusterInfo.IngressDomain)
+		} else if len(options.KubernetesResources.Ingresses) > 0 {
+			// If Ingresses were provided, get the first Ingress
+			ingress = &options.KubernetesResources.Ingresses[0]
+		}
+	} else {
+		if len(options.KubernetesResources.Routes) == 0 && options.TargetPort != 0 {
+			// If no Routes were provided and TargetPort is not 0, generate the Route
+			route = generateRoute(options)
+		} else if len(options.KubernetesResources.Routes) > 0 {
+			// If Routes were provided, get the first Route
+			route = &options.KubernetesResources.Routes[0]
+		}
+	}
+
+	if ingress != nil {
+		k.AddResources(ingressFileName)
+		resources[ingressFileName] = ingress
+	}
+
+	if route != nil {
+		k.AddResources(routeFileName)
+		resources[routeFileName] = route
+	}
 
 	// add back custom kustomization patches
 	k.CompareDifferenceAndAddCustomPatches(originalKustomizeFileContent.Patches, componentGeneratedResources[options.Name])
 
-	resources := map[string]interface{}{
-		deploymentPatchFileName: deploymentPatch,
-		kustomizeFileName:       k,
-	}
+	resources[kustomizeFileName] = k
 
 	_, err = yaml.WriteResources(fs, outputFolder, resources)
 	return err
@@ -405,6 +436,61 @@ func generateService(options gitopsv1alpha1.GeneratorOptions) *corev1.Service {
 	}
 
 	return &service
+}
+
+func generateIngress(options gitopsv1alpha1.GeneratorOptions, ingressDomain string) *networkingv1.Ingress {
+
+	ingressName := options.Name
+	if len(ingressName) >= 30 {
+		ingressName = ingressName[0:25] + util.GetRandomString(4, true)
+	}
+	k8sLabels := generateK8sLabels(options)
+
+	implementationSpecific := networkingv1.PathTypeImplementationSpecific
+
+	ingress := networkingv1.Ingress{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: options.Namespace,
+			Labels:    k8sLabels,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &implementationSpecific,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: options.Name,
+											Port: networkingv1.ServiceBackendPort{
+												Number: int32(options.TargetPort),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if options.Route != "" {
+		if len(ingress.Spec.Rules) > 0 {
+			ingress.Spec.Rules[0].Host = options.Route
+		}
+	}
+
+	return nil
 }
 
 func generateRoute(options gitopsv1alpha1.GeneratorOptions) *routev1.Route {

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -136,7 +136,7 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, options 
 }
 
 // GenerateOverlays generates the overlays director in an existing GitOps structure
-func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, options gitopsv1alpha1.GeneratorOptions, imageName, namespace string, clusterInfo ClusterInfo, componentGeneratedResources map[string][]string) error {
+func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, options gitopsv1alpha1.GeneratorOptions, imageName, namespace string, componentGeneratedResources map[string][]string) error {
 	kustomizeFileExist, err := fs.Exists(filepath.Join(outputFolder, kustomizeFileName))
 	if err != nil {
 		return err
@@ -195,10 +195,10 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 	var ingress *networkingv1.Ingress
 
 	// Create an ingress if its a Kubernetes cluster, route if its an OpenShift cluster
-	if clusterInfo.IsKubernetesCluster {
+	if options.IsKubernetesCluster {
 		if len(options.KubernetesResources.Ingresses) == 0 && options.TargetPort != 0 {
 			// If no Ingresses were provided and TargetPort is not 0, generate the Ingress
-			ingress = generateIngress(options, clusterInfo.IngressDomain)
+			ingress = generateIngress(options)
 		} else if len(options.KubernetesResources.Ingresses) > 0 {
 			// If Ingresses were provided, get the first Ingress
 			ingress = &options.KubernetesResources.Ingresses[0]
@@ -438,7 +438,7 @@ func generateService(options gitopsv1alpha1.GeneratorOptions) *corev1.Service {
 	return &service
 }
 
-func generateIngress(options gitopsv1alpha1.GeneratorOptions, ingressDomain string) *networkingv1.Ingress {
+func generateIngress(options gitopsv1alpha1.GeneratorOptions) *networkingv1.Ingress {
 
 	ingressName := options.Name
 	if len(ingressName) >= 30 {
@@ -490,7 +490,7 @@ func generateIngress(options gitopsv1alpha1.GeneratorOptions, ingressDomain stri
 		}
 	}
 
-	return nil
+	return &ingress
 }
 
 func generateRoute(options gitopsv1alpha1.GeneratorOptions) *routev1.Route {

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -441,9 +441,6 @@ func generateService(options gitopsv1alpha1.GeneratorOptions) *corev1.Service {
 func generateIngress(options gitopsv1alpha1.GeneratorOptions) *networkingv1.Ingress {
 
 	ingressName := options.Name
-	if len(ingressName) >= 30 {
-		ingressName = ingressName[0:25] + util.GetRandomString(4, true)
-	}
 	k8sLabels := generateK8sLabels(options)
 
 	implementationSpecific := networkingv1.PathTypeImplementationSpecific
@@ -484,10 +481,8 @@ func generateIngress(options gitopsv1alpha1.GeneratorOptions) *networkingv1.Ingr
 		},
 	}
 
-	if options.Route != "" {
-		if len(ingress.Spec.Rules) > 0 {
-			ingress.Spec.Rules[0].Host = options.Route
-		}
+	if options.Route != "" && len(ingress.Spec.Rules) > 0 {
+		ingress.Spec.Rules[0].Host = options.Route
 	}
 
 	return &ingress

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -676,16 +676,237 @@ func TestGenerateRoute(t *testing.T) {
 	}
 }
 
-func TestGenerateOverlays(t *testing.T) {
-	component := gitopsv1alpha1.GeneratorOptions{
-		Name: "test-component",
+func TestGenerateIngress(t *testing.T) {
+	applicationName := "test-application"
+	componentName := "test-component"
+	namespace := "test-namespace"
+	customK8sLabels := map[string]string{
+		"app.kubernetes.io/name":       componentName,
+		"app.kubernetes.io/instance":   "ComponentCRName",
+		"app.kubernetes.io/part-of":    applicationName,
+		"app.kubernetes.io/managed-by": "kustomize",
+		"app.kubernetes.io/created-by": "GitOps Generator Test",
 	}
+	k8slabels := map[string]string{
+		"app.kubernetes.io/name":       componentName,
+		"app.kubernetes.io/instance":   componentName,
+		"app.kubernetes.io/part-of":    applicationName,
+		"app.kubernetes.io/managed-by": "kustomize",
+		"app.kubernetes.io/created-by": "application-service",
+	}
+	implementationSpecific := networkingv1.PathTypeImplementationSpecific
+
+	tests := []struct {
+		name        string
+		options     gitopsv1alpha1.GeneratorOptions
+		wantIngress networkingv1.Ingress
+	}{
+		{
+			name: "Simple options object",
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name:        componentName,
+				Namespace:   namespace,
+				Application: applicationName,
+				TargetPort:  5000,
+				Route:       componentName + ".example.com",
+			},
+			wantIngress: networkingv1.Ingress{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+					Labels:    k8slabels,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &implementationSpecific,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: componentName,
+													Port: networkingv1.ServiceBackendPort{
+														Number: 5000,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Host: componentName + ".example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Options object with custom k8s labels set",
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name:        componentName,
+				Namespace:   namespace,
+				Application: applicationName,
+				TargetPort:  5000,
+				K8sLabels:   customK8sLabels,
+				Route:       componentName + ".example.com",
+			},
+			wantIngress: networkingv1.Ingress{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+					Labels:    customK8sLabels,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &implementationSpecific,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: componentName,
+													Port: networkingv1.ServiceBackendPort{
+														Number: 5000,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Host: componentName + ".example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Generated ingress with trimmed CR name",
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name:        "some-longer-component-name-test-string",
+				Namespace:   namespace,
+				Application: applicationName,
+				TargetPort:  5000,
+				K8sLabels: map[string]string{
+					"app.kubernetes.io/name":       "some-longer-component-name-test-string",
+					"app.kubernetes.io/instance":   "ComponentCRName",
+					"app.kubernetes.io/part-of":    applicationName,
+					"app.kubernetes.io/managed-by": "kustomize",
+					"app.kubernetes.io/created-by": "GitOps Generator Test",
+				},
+				Route: componentName + ".example.com",
+			},
+			wantIngress: networkingv1.Ingress{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "some-longer-component-name-test-string",
+						"app.kubernetes.io/instance":   "ComponentCRName",
+						"app.kubernetes.io/part-of":    applicationName,
+						"app.kubernetes.io/managed-by": "kustomize",
+						"app.kubernetes.io/created-by": "GitOps Generator Test",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &implementationSpecific,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "some-longer-component-name-test-string",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 5000,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Host: componentName + ".example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generatedIngress := generateIngress(tt.options)
+			if len(generatedIngress.Name) > 30 {
+				t.Errorf("TestGenerateIngress() error: expected CR name of length 30, got %v", len(generatedIngress.Name))
+			}
+
+			if tt.name == "Generated ingress with trimmed CR name" {
+				trimmedComponentName := "some-longer-component-nam"
+				if !strings.Contains(generatedIngress.Name, trimmedComponentName) {
+					t.Errorf("TestGenerateRoute() error: expected component CR name to contain %v got %v", tt.wantIngress, generatedIngress)
+				}
+
+				tt.wantIngress.Name = generatedIngress.Name
+			}
+			if !reflect.DeepEqual(*generatedIngress, tt.wantIngress) {
+				t.Errorf("TestGenerateRoute() error: expected %v got %v", tt.wantIngress, *generatedIngress)
+			}
+		})
+	}
+}
+
+func TestGenerateOverlays(t *testing.T) {
+
 	imageName := "test-image"
 	namespace := "test-namespace"
 	containerName := "test-container"
 
 	fs := ioutils.NewMemoryFilesystem()
 	readOnlyFs := ioutils.NewReadOnlyFs()
+
+	route1 := routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "route1",
+		},
+	}
+	route2 := routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "route2",
+		},
+	}
+
+	ingress1 := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress1",
+		},
+	}
+	ingress2 := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress2",
+		},
+	}
 
 	// Prepopulate the fs with components
 	gitOpsFolder := "/tmp/gitops"
@@ -762,40 +983,127 @@ func TestGenerateOverlays(t *testing.T) {
 	tests := []struct {
 		name                        string
 		fs                          afero.Afero
+		options                     gitopsv1alpha1.GeneratorOptions
 		outputFolder                string
 		expectPatchEntries          int
 		componentGeneratedResources map[string][]string
 		wantErr                     string
 	}{
 		{
-			name:               "simple success case",
-			fs:                 fs,
+			name: "simple success case",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+			},
 			outputFolder:       outputFolder,
 			expectPatchEntries: 1,
 			wantErr:            "",
 		},
 		{
-			name:               "existing kustomization file with custom patches",
-			fs:                 fs,
+			name: "simple success case on OpenShift with Routes",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+				KubernetesResources: gitopsv1alpha1.KubernetesResources{
+					Routes: []routev1.Route{
+						route1,
+						route2,
+					},
+					Ingresses: []networkingv1.Ingress{
+						ingress1,
+						ingress2,
+					},
+				},
+			},
+			outputFolder:       outputFolder,
+			expectPatchEntries: 1,
+			wantErr:            "",
+		},
+		{
+			name: "simple success case on OpenShift where Route is generated",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name:       "test-component",
+				TargetPort: 8080,
+				KubernetesResources: gitopsv1alpha1.KubernetesResources{
+					Ingresses: []networkingv1.Ingress{
+						ingress1,
+						ingress2,
+					},
+				},
+			},
+			outputFolder:       outputFolder,
+			expectPatchEntries: 1,
+			wantErr:            "",
+		},
+		{
+			name: "simple success case on Kuberntes with Ingresses",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+				KubernetesResources: gitopsv1alpha1.KubernetesResources{
+					Routes: []routev1.Route{
+						route1,
+						route2,
+					},
+					Ingresses: []networkingv1.Ingress{
+						ingress1,
+						ingress2,
+					},
+				},
+				IsKubernetesCluster: true,
+			},
+			outputFolder:       outputFolder,
+			expectPatchEntries: 1,
+			wantErr:            "",
+		},
+		{
+			name: "simple success case on OpenShift where Ingress is generated",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name:                "test-component",
+				TargetPort:          8080,
+				KubernetesResources: gitopsv1alpha1.KubernetesResources{},
+				IsKubernetesCluster: true,
+			},
+			outputFolder:       outputFolder,
+			expectPatchEntries: 1,
+			wantErr:            "",
+		},
+		{
+			name: "existing kustomization file with custom patches",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+			},
 			outputFolder:       outputFolderWithKustomizationFile,
 			expectPatchEntries: 3,
 			wantErr:            "",
 		},
 		{
-			name:         "read only fs",
-			fs:           readOnlyFs,
+			name: "read only fs",
+			fs:   readOnlyFs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+			},
 			outputFolder: outputFolderWithKustomizationFile,
 			wantErr:      "failed to MkDirAll",
 		},
 		{
-			name:         "unmarshall error",
-			fs:           fs,
+			name: "unmarshall error",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+			},
 			outputFolder: invalidKustomizationFileFolder,
 			wantErr:      " failed to unmarshal data: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field Kustomization.resources",
 		},
 		{
-			name:         "genereated an additional patch",
-			fs:           fs,
+			name: "genereated an additional patch",
+			fs:   fs,
+			options: gitopsv1alpha1.GeneratorOptions{
+				Name: "test-component",
+			},
 			outputFolder: outputFolderWithKustomizationFile,
 			componentGeneratedResources: map[string][]string{
 				"test-component": {
@@ -809,7 +1117,7 @@ func TestGenerateOverlays(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := GenerateOverlays(tt.fs, gitOpsFolder, tt.outputFolder, component, imageName, namespace, ClusterInfo{}, tt.componentGeneratedResources)
+			err := GenerateOverlays(tt.fs, gitOpsFolder, tt.outputFolder, tt.options, imageName, namespace, tt.componentGeneratedResources)
 
 			if !testutils.ErrorMatch(t, tt.wantErr, err) {
 				t.Errorf("unexpected error return value. Got %v", err)
@@ -831,7 +1139,10 @@ func TestGenerateOverlays(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error reading deployment file")
 				}
-				yaml.Unmarshal(deploymentPatchBytes, &deployPatch)
+				err = yaml.Unmarshal(deploymentPatchBytes, &deployPatch)
+				if err != nil {
+					t.Errorf("unexpected error unmarshaling file")
+				}
 				if deployPatch.Spec.Template.Spec.Containers[0].Name != containerName {
 					t.Errorf("expected container name %v, got %v", containerName, deployPatch.Spec.Template.Spec.Containers[0].Name)
 				}
@@ -846,14 +1157,71 @@ func TestGenerateOverlays(t *testing.T) {
 					t.Errorf("kustomize file does not exist at path %v", kustomizationFilepath)
 				}
 
+				if tt.options.IsKubernetesCluster {
+					// Validate that the ingress.yaml got created successfully and contains the proper entries
+					ingressFilepath := filepath.Join(tt.outputFolder, "ingress.yaml")
+					exists, err = tt.fs.Exists(ingressFilepath)
+					if err != nil {
+						t.Errorf("unexpected error checking if ingress file exists %v", err)
+					}
+					if !exists && tt.options.TargetPort != 0 {
+						t.Errorf("ingress file does not exist at path %v", ingressFilepath)
+					} else if exists {
+						ingress := networkingv1.Ingress{}
+						ingressBytes, err := tt.fs.ReadFile(ingressFilepath)
+						if err != nil {
+							t.Errorf("unexpected error reading deployment file")
+						}
+						err = yaml.Unmarshal(ingressBytes, &ingress)
+						if err != nil {
+							t.Errorf("unexpected error unmarshaling file")
+						}
+						if len(tt.options.KubernetesResources.Ingresses) > 0 && ingress.Name != tt.options.KubernetesResources.Ingresses[0].Name {
+							t.Errorf("expected ingress name %v, got %v", tt.options.KubernetesResources.Ingresses[0].Name, ingress.Name)
+						} else if len(tt.options.KubernetesResources.Ingresses) == 0 && ingress.Name != tt.options.Name {
+							t.Errorf("expected ingress name %v, got %v", tt.options.Name, ingress.Name)
+						}
+					}
+
+				}
+
+				if !tt.options.IsKubernetesCluster {
+					// Validate that the route.yaml got created successfully and contains the proper entries
+					routeFilepath := filepath.Join(tt.outputFolder, "route.yaml")
+					exists, err = tt.fs.Exists(routeFilepath)
+					if err != nil {
+						t.Errorf("unexpected error checking if ingress file exists %v", err)
+					}
+					if !exists && tt.options.TargetPort != 0 {
+						t.Errorf("route file does not exist at path %v", routeFilepath)
+					} else if exists {
+						route := routev1.Route{}
+						routeBytes, err := tt.fs.ReadFile(routeFilepath)
+						if err != nil {
+							t.Errorf("unexpected error reading deployment file")
+						}
+						err = yaml.Unmarshal(routeBytes, &route)
+						if err != nil {
+							t.Errorf("unexpected error unmarshaling file")
+						}
+						if len(tt.options.KubernetesResources.Routes) > 0 && route.Name != tt.options.KubernetesResources.Routes[0].Name {
+							t.Errorf("expected route name %v, got %v", tt.options.KubernetesResources.Routes[0].Name, route.Name)
+						} else if len(tt.options.KubernetesResources.Routes) == 0 && route.Name != tt.options.Name {
+							t.Errorf("expected route name %v, got %v", tt.options.Name, route.Name)
+						}
+					}
+				}
+
 				// Read the kustomization.yaml and validate its entries
 				k := resources.Kustomization{}
 				kustomizationBytes, err := tt.fs.ReadFile(kustomizationFilepath)
 				if err != nil {
 					t.Errorf("unexpected error reading parent kustomize file")
 				}
-				yaml.Unmarshal(kustomizationBytes, &k)
-
+				err = yaml.Unmarshal(kustomizationBytes, &k)
+				if err != nil {
+					t.Errorf("unexpected error unmarshaling file")
+				}
 				// There match patch entries in the kustomization file
 				if len(k.Patches) != tt.expectPatchEntries {
 					t.Errorf("expected %v kustomization bases, got %v patches: %v", tt.expectPatchEntries, len(k.Patches), k.Patches)
@@ -937,7 +1305,6 @@ func TestGenerate(t *testing.T) {
 	others2 := []interface{}{
 		pod1,
 		deployment2,
-		ingress1,
 		ingress2,
 	}
 
@@ -1018,13 +1385,12 @@ func TestGenerate(t *testing.T) {
 				kustomizeFileName: resources.Kustomization{
 					APIVersion: "kustomize.config.k8s.io/v1beta1",
 					Kind:       "Kustomization",
-					Resources:  []string{deploymentFileName, routeFileName},
+					Resources:  []string{deploymentFileName},
 				},
-				"route.yaml": route1,
 			},
 		},
 		{
-			name: "Single deployment object provided only, with Target Port should generate svc and route too",
+			name: "Single deployment object provided only, with Target Port should generate svc",
 			fs:   fs,
 			component: gitopsv1alpha1.GeneratorOptions{
 				Name:        componentName,
@@ -1038,12 +1404,11 @@ func TestGenerate(t *testing.T) {
 				TargetPort: 1234,
 			},
 			isServicetGenerated: true,
-			isRouteGenerated:    true,
 			wantFiles: map[string]interface{}{
 				kustomizeFileName: resources.Kustomization{
 					APIVersion: "kustomize.config.k8s.io/v1beta1",
 					Kind:       "Kustomization",
-					Resources:  []string{deploymentFileName, routeFileName, serviceFileName},
+					Resources:  []string{deploymentFileName, serviceFileName},
 				},
 				deploymentFileName: deployment1,
 			},
@@ -1076,11 +1441,10 @@ func TestGenerate(t *testing.T) {
 				kustomizeFileName: resources.Kustomization{
 					APIVersion: "kustomize.config.k8s.io/v1beta1",
 					Kind:       "Kustomization",
-					Resources:  []string{deploymentFileName, otherFileName, routeFileName, serviceFileName},
+					Resources:  []string{deploymentFileName, otherFileName, serviceFileName},
 				},
 				deploymentFileName: deployment1,
 				serviceFileName:    service1,
-				routeFileName:      route1,
 				otherFileName:      others1,
 			},
 		},

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -1159,7 +1159,7 @@ func TestGenerateOverlays(t *testing.T) {
 
 				if tt.options.IsKubernetesCluster {
 					// Validate that the ingress.yaml got created successfully and contains the proper entries
-					ingressFilepath := filepath.Join(tt.outputFolder, "ingress.yaml")
+					ingressFilepath := filepath.Join(tt.outputFolder, ingressFileName)
 					exists, err = tt.fs.Exists(ingressFilepath)
 					if err != nil {
 						t.Errorf("unexpected error checking if ingress file exists %v", err)
@@ -1187,7 +1187,7 @@ func TestGenerateOverlays(t *testing.T) {
 
 				if !tt.options.IsKubernetesCluster {
 					// Validate that the route.yaml got created successfully and contains the proper entries
-					routeFilepath := filepath.Join(tt.outputFolder, "route.yaml")
+					routeFilepath := filepath.Join(tt.outputFolder, routeFileName)
 					exists, err = tt.fs.Exists(routeFilepath)
 					if err != nil {
 						t.Errorf("unexpected error checking if ingress file exists %v", err)

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -809,7 +809,7 @@ func TestGenerateOverlays(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := GenerateOverlays(tt.fs, gitOpsFolder, tt.outputFolder, component, imageName, namespace, tt.componentGeneratedResources)
+			err := GenerateOverlays(tt.fs, gitOpsFolder, tt.outputFolder, component, imageName, namespace, ClusterInfo{}, tt.componentGeneratedResources)
 
 			if !testutils.ErrorMatch(t, tt.wantErr, err) {
 				t.Errorf("unexpected error return value. Got %v", err)

--- a/pkg/gitops.go
+++ b/pkg/gitops.go
@@ -310,12 +310,11 @@ func (s Gen) GenerateAndPush(outputPath string, remote string, options gitopsv1a
 // 6. environmentName: The name of the environment
 // 7. imageName: The image name of the source
 // 8  namespace: The namespace of the component. This is used in as the namespace of the deployment yaml.
-// 9. clusterInfo: Cluster environment information - OpenShift or Kubernetes cluster, Ingress Domain
-// 10. The filesystem object used to create (either ioutils.NewFilesystem() or ioutils.NewMemoryFilesystem())
-// 11. The branch to push to
-// 12. The path within the repository to generate the resources in
-// 13. Push the changes to the repository or not.
-// 14. The gitops config containing the build bundle;
+// 9. The filesystem object used to create (either ioutils.NewFilesystem() or ioutils.NewMemoryFilesystem())
+// 10. The branch to push to
+// 11. The path within the repository to generate the resources in
+// 12. Push the changes to the repository or not.
+// 13. The gitops config containing the build bundle;
 func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error {
 
 	if clone || doPush {

--- a/pkg/gitops.go
+++ b/pkg/gitops.go
@@ -49,7 +49,7 @@ type Generator interface {
 	CloneGenerateAndPush(outputPath string, remote string, options gitopsv1alpha1.GeneratorOptions, appFs afero.Afero, branch string, context string, doPush bool) error
 	CommitAndPush(outputPath string, repoPathOverride string, remote string, componentName string, branch string, commitMessage string) error
 	GenerateAndPush(outputPath string, remote string, options gitopsv1alpha1.GeneratorOptions, appFs afero.Afero, branch string, doPush bool, createdBy string) error
-	GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, clusterInfo ClusterInfo, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error
+	GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error
 	GitRemoveComponent(outputPath string, remote string, componentName string, branch string, context string) error
 	CloneRepo(outputPath string, remote string, componentName string, branch string) error
 	GetCommitIDFromRepo(fs afero.Afero, repoPath string) (string, error)
@@ -301,11 +301,6 @@ func (s Gen) GenerateAndPush(outputPath string, remote string, options gitopsv1a
 	return nil
 }
 
-type ClusterInfo struct {
-	IsKubernetesCluster bool
-	IngressDomain       string
-}
-
 // GenerateOverlaysAndPush generates the overlays kustomize from App Env Snapshot Binding Spec
 // 1. outputPath: Where to output the gitops resources to
 // 2. clone: Optionally clone the repository first
@@ -321,7 +316,7 @@ type ClusterInfo struct {
 // 12. The path within the repository to generate the resources in
 // 13. Push the changes to the repository or not.
 // 14. The gitops config containing the build bundle;
-func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, clusterInfo ClusterInfo, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error {
+func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote string, options gitopsv1alpha1.GeneratorOptions, applicationName, environmentName, imageName, namespace string, appFs afero.Afero, branch string, context string, doPush bool, componentGeneratedResources map[string][]string) error {
 
 	if clone || doPush {
 		invalidRemoteErr := util.ValidateRemote(remote)
@@ -350,7 +345,7 @@ func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote strin
 	gitopsFolder := filepath.Join(repoPath, context)
 	componentEnvOverlaysPath := filepath.Join(gitopsFolder, "components", componentName, "overlays", environmentName)
 
-	if err := GenerateOverlays(appFs, gitopsFolder, componentEnvOverlaysPath, options, imageName, namespace, clusterInfo, componentGeneratedResources); err != nil {
+	if err := GenerateOverlays(appFs, gitopsFolder, componentEnvOverlaysPath, options, imageName, namespace, componentGeneratedResources); err != nil {
 		return &GitGenResourcesAndOverlaysError{path: componentEnvOverlaysPath, componentName: componentName, err: err, cmdType: genOverlays}
 	}
 

--- a/pkg/gitops.go
+++ b/pkg/gitops.go
@@ -328,6 +328,7 @@ func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote strin
 	repoPath := filepath.Join(outputPath, applicationName)
 
 	if clone {
+		s.Log.V(6).Info("Cloning the GitOps repository")
 		if out, err := execute(outputPath, GitCommand, "clone", remote, applicationName); err != nil {
 			return &GitCmdError{path: outputPath, cmdResult: string(out), err: err, cmdType: cloneRepo}
 		}
@@ -344,11 +345,13 @@ func (s Gen) GenerateOverlaysAndPush(outputPath string, clone bool, remote strin
 	gitopsFolder := filepath.Join(repoPath, context)
 	componentEnvOverlaysPath := filepath.Join(gitopsFolder, "components", componentName, "overlays", environmentName)
 
+	s.Log.V(6).Info("Generating the overlays resources")
 	if err := GenerateOverlays(appFs, gitopsFolder, componentEnvOverlaysPath, options, imageName, namespace, componentGeneratedResources); err != nil {
 		return &GitGenResourcesAndOverlaysError{path: componentEnvOverlaysPath, componentName: componentName, err: err, cmdType: genOverlays}
 	}
 
 	if doPush {
+		s.Log.V(6).Info("Committing and pushing the overlays resources")
 		return s.CommitAndPush(outputPath, applicationName, remote, componentName, branch, fmt.Sprintf("Generate %s environment overlays for component %s", environmentName, componentName))
 	}
 	return nil

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -1848,7 +1848,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, ClusterInfo{}, tt.fs, branch, "/", true, generatedResources)
+			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, tt.fs, branch, "/", true, generatedResources)
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)

--- a/pkg/gitops_test.go
+++ b/pkg/gitops_test.go
@@ -1848,7 +1848,7 @@ func TestGenerateOverlaysAndPush(t *testing.T) {
 
 			execute = newTestExecute(outputStack, tt.errors, &executedCmds)
 
-			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, tt.fs, branch, "/", true, generatedResources)
+			err := generator.GenerateOverlaysAndPush(outputPath, true, repo, tt.component, tt.applicationName, tt.environmentName, tt.imageName, tt.namespace, ClusterInfo{}, tt.fs, branch, "/", true, generatedResources)
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Moves the Route resource generation from base to overlays dir
- Generate Ingress resource in overlays dir
- Generate either Route/Ingress in overlays depending on Cluster information
- Update test

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-329

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
Here is an example of the Gitops resource generation from this branch:

1. OpenShift: https://github.com/maysunfaisal/application-sample-lK5Sb-work-occur generates Route in overlays
2. Kubernetes: https://github.com/maysunfaisal/application-sample-lK5Sb-lend-enjoy generates Ingress in overlays