### PR TITLE
[RHTAPBUGS-410] Allow route name to be passed in

### DIFF
--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -71,8 +71,12 @@ type GeneratorOptions struct {
 	// The port to expose the component over. Referenced in generated service.yaml and route.yaml
 	TargetPort int `json:"targetPort,omitempty"`
 
-	// The route to expose the component with. Referenced in generated route.yaml
+	// The route host name to expose the component with. Referenced in generated route.yaml
 	Route string `json:"route,omitempty"`
+
+	// The name of the route to be generated. If empty, the Component name will be used. Referenced in route.yaml
+	// Should be under 30 characters, if over, it will be trimmed to ensure compatibility with generated hostnames
+	RouteName string `json:"routeName,omitempty"`
 
 	// An array of environment variables to add to the component.  BaseEnvVar describes environment variables to use for the component
 	BaseEnvVar []corev1.EnvVar `json:"env,omitempty"`

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -489,12 +489,21 @@ func generateIngress(options gitopsv1alpha1.GeneratorOptions) *networkingv1.Ingr
 }
 
 func generateRoute(options gitopsv1alpha1.GeneratorOptions) *routev1.Route {
+
+	// If a specific Route name was passed in, use it, otherwise use the Component's name
+	var routeName string
+	if options.RouteName != "" {
+		routeName = options.RouteName
+	} else {
+		routeName = options.Name
+
+	}
 	// Trim the generated route name to under 30 characters (plus a few random characters for uniqueness)
 	// To ensure issues where the generated hostname (componentName-namespace) is too long
-	routeName := options.Name
 	if len(routeName) >= 30 {
 		routeName = routeName[0:25] + util.GetRandomString(4, true)
 	}
+
 	k8sLabels := generateK8sLabels(options)
 	weight := int32(100)
 	route := routev1.Route{

--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -652,6 +652,44 @@ func TestGenerateRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Component object with custom route name set",
+			component: gitopsv1alpha1.GeneratorOptions{
+				Name:        componentName,
+				Namespace:   namespace,
+				Application: applicationName,
+				TargetPort:  5000,
+				K8sLabels:   customK8sLabels,
+				Route:       "example.com",
+				RouteName:   "my-route-name",
+			},
+			wantRoute: routev1.Route{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Route",
+					APIVersion: "route.openshift.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "my-route-name",
+					Namespace: namespace,
+					Labels:    customK8sLabels,
+				},
+				Spec: routev1.RouteSpec{
+					Host: "example.com",
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromInt(5000),
+					},
+					TLS: &routev1.TLSConfig{
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+						Termination:                   routev1.TLSTerminationEdge,
+					},
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   componentName,
+						Weight: &weight,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?:
This PR updates the gitops-generator to allow a custom route name to be passed in. In HAS, we've found that we need to use route names that differ from what the gitops-generator uses by default, and allowing HAS to pass in its own route names to the gitops-generator will allow us to do that.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-410

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
