### PR TITLE
Update the Kustomize Patch syntax

### DIFF
--- a/pkg/generate_test.go
+++ b/pkg/generate_test.go
@@ -933,7 +933,14 @@ func TestGenerateOverlays(t *testing.T) {
 	fs.MkdirAll(outputFolderWithKustomizationFile, 0755)
 	preExistKustomizationFilepath := filepath.Join(outputFolderWithKustomizationFile, "kustomization.yaml")
 	k := resources.Kustomization{
-		Patches: []string{"patch1.yaml", "custom-patch1.yaml"},
+		Patches: []resources.Patch{
+			{
+				Path: "patch1.yaml",
+			},
+			{
+				Path: "custom-patch1.yaml",
+			},
+		},
 	}
 	bytes, err = yaml.Marshal(k)
 	if err != nil {

--- a/pkg/resources/kustomization_test.go
+++ b/pkg/resources/kustomization_test.go
@@ -44,7 +44,7 @@ func Test_AddPatches(t *testing.T) {
 	k := Kustomization{}
 	k.AddPatches("testing.yaml", "testing2.yaml")
 
-	if diff := cmp.Diff([]string{"testing.yaml", "testing2.yaml"}, k.Patches); diff != "" {
+	if diff := cmp.Diff([]string{"testing.yaml", "testing2.yaml"}, getPatchFiles(k.Patches)); diff != "" {
 		t.Fatalf("failed to add resources:\n%s", diff)
 	}
 }
@@ -70,10 +70,69 @@ func Test_AddResource_sorts_elements(t *testing.T) {
 
 func Test_CompareDifferenceAndAddCustomizedPatches(t *testing.T) {
 	k := Kustomization{}
-	original := []string{"testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}
+	original := []Patch{
+		{
+			Path: "testing.yaml",
+		},
+		{
+			Path: "testing2.yaml",
+		},
+		{
+			Path: "custom.yaml",
+		},
+		{
+			Path: "custom2.yaml",
+		},
+	}
 	generated := []string{"testing.yaml", "testing2.yaml", "testing3.yaml"}
 	k.CompareDifferenceAndAddCustomPatches(original, generated)
-	if diff := cmp.Diff([]string{"testing3.yaml", "testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}, k.Patches); diff != "" {
+	if diff := cmp.Diff([]string{"testing3.yaml", "testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}, getPatchFiles(k.Patches)); diff != "" {
 		t.Fatalf("failed to add customized patches:\n%s", diff)
+	}
+}
+
+func Test_GetPatchFiles(t *testing.T) {
+
+	original := []Patch{
+		{
+			Path: "testing.yaml",
+		},
+		{
+			Path: "testing2.yaml",
+		},
+		{
+			Path: "custom.yaml",
+		},
+		{
+			Path: "custom2.yaml",
+		},
+	}
+	want := []string{"testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}
+	got := getPatchFiles(original)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("failed to get patch files:\n%s", diff)
+	}
+}
+
+func Test_AddFilestoPatches(t *testing.T) {
+
+	want := []Patch{
+		{
+			Path: "testing.yaml",
+		},
+		{
+			Path: "testing2.yaml",
+		},
+		{
+			Path: "custom.yaml",
+		},
+		{
+			Path: "custom2.yaml",
+		},
+	}
+	files := []string{"testing.yaml", "testing2.yaml", "custom.yaml", "custom2.yaml"}
+	got := addFilestoPatches(files)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("failed to add patch files:\n%s", diff)
 	}
 }


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR updates the Patch syntax because kustomize 5.1.0 does not support patch list without `path` anymore. 

See the Kustomize release notes https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0
 
Here is the repo generated with this branch https://github.com/maysunfaisal/application-sample-lK5Sb-wan-score/blob/main/components/component-sample/overlays/staging/kustomization.yaml#L4 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/RHTAPBUGS-528

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
- Git clone https://github.com/maysunfaisal/application-sample-lK5Sb-wan-score and run `kustomize build .`
- Upgrade to Kustomize 5.1.0 to test it out
- Also works with Kustomize 4.5.2

```
MacBook-Pro:staging maysun$ pwd
/Users/maysun/dev/appstudio/misc/application-sample-lK5Sb-wan-score/components/component-sample/overlays/staging

MacBook-Pro:staging maysun$ ls -la
total 24
drwxr-xr-x  5 maysun  staff  160 31 Jul 15:06 .
drwxr-xr-x  3 maysun  staff   96 31 Jul 15:06 ..
-rw-r--r--  1 maysun  staff  634 31 Jul 15:06 deployment-patch.yaml
-rw-r--r--  1 maysun  staff  140 31 Jul 15:06 kustomization.yaml
-rw-r--r--  1 maysun  staff  504 31 Jul 15:06 route.yaml

MacBook-Pro:staging maysun$ kustomize version
v5.1.0

MacBook-Pro:staging maysun$ kustomize build .
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app.kubernetes.io/created-by: application-service
    app.kubernetes.io/instance: component-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: component-sample
    app.kubernetes.io/part-of: application-sample
  name: component-sample
spec:
  ports:
  - name: http-8081
    port: 8081
    protocol: TCP
    targetPort: 8081


[...]
```