### PR TITLE
[RHTAPBUGS-349] Support StatefulSets and DaemonSets

### DIFF
--- a/api/v1alpha1/generator_options.go
+++ b/api/v1alpha1/generator_options.go
@@ -31,11 +31,13 @@ type GitSource struct {
 
 // KubernetesResources define the list of Kubernetes resources
 type KubernetesResources struct {
-	Deployments []appsv1.Deployment
-	Services    []corev1.Service
-	Routes      []routev1.Route
-	Ingresses   []networkingv1.Ingress
-	Others      []interface{}
+	DaemonSets   []appsv1.DaemonSet
+	Deployments  []appsv1.Deployment
+	StatefulSets []appsv1.StatefulSet
+	Services     []corev1.Service
+	Routes       []routev1.Route
+	Ingresses    []networkingv1.Ingress
+	Others       []interface{}
 }
 
 // GeneratorOptions - This captures the options for generating the component's GitOps resources for a component of an

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -580,7 +580,7 @@ func generateDaemonSetPatch(options gitopsv1alpha1.GeneratorOptions, imageName, 
 	}
 
 	for _, env := range options.BaseEnvVar {
-		statefulSet.Spec.Template.Spec.Containers[0].Env = append(statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+		daemonSet.Spec.Template.Spec.Containers[0].Env = append(daemonSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  env.Name,
 			Value: env.Value,
 		})
@@ -589,7 +589,7 @@ func generateDaemonSetPatch(options gitopsv1alpha1.GeneratorOptions, imageName, 
 	// only add the environment env configurations, if a deployment/binding env is not present with the same env name
 	for _, env := range options.OverlayEnvVar {
 		isPresent := false
-		for _, statefulSetEnv := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		for _, statefulSetEnv := range daemonSet.Spec.Template.Spec.Containers[0].Env {
 			if statefulSetEnv.Name == env.Name {
 				isPresent = true
 				break
@@ -597,16 +597,16 @@ func generateDaemonSetPatch(options gitopsv1alpha1.GeneratorOptions, imageName, 
 		}
 
 		if !isPresent {
-			statefulSet.Spec.Template.Spec.Containers[0].Env = append(statefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			daemonSet.Spec.Template.Spec.Containers[0].Env = append(daemonSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  env.Name,
 				Value: env.Value,
 			})
 		}
 	}
 
-	statefulSet.Spec.Template.Spec.Containers[0].Resources = options.Resources
+	daemonSet.Spec.Template.Spec.Containers[0].Resources = options.Resources
 
-	return &statefulSet
+	return &daemonSet
 }
 
 func generateService(options gitopsv1alpha1.GeneratorOptions) *corev1.Service {

--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -555,7 +555,7 @@ func generateStatefulSetPatch(options gitopsv1alpha1.GeneratorOptions, imageName
 
 func generateDaemonSetPatch(options gitopsv1alpha1.GeneratorOptions, imageName, containerName, namespace string) *appsv1.DaemonSet {
 
-	statefulSet := appsv1.DaemonSet{
+	daemonSet := appsv1.DaemonSet{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "DaemonSet",
 			APIVersion: "apps/v1",


### PR DESCRIPTION
### What does this PR do?:
This PR updates the gitops-generator to ensure that StatefulSet and DaemonSet resources are treated at the same level as Deployments:
- If a StatefulSet / DaemonSet is provided in lieu of a Deployment, they will be stored in `statefulset.yaml` / `daemonset.yaml` in the gitops resources base folder.
- When overlays are generated, patch files will be generated for the StatefulSet / DaemonSet.
- If no resources are provided, a `Deployment` resource is still generated by default.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-349

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
